### PR TITLE
fix(firefox): self-heal stale compatibility.ini in profile launcher

### DIFF
--- a/modules/browser/firefox/profile-apps.nix
+++ b/modules/browser/firefox/profile-apps.nix
@@ -232,6 +232,26 @@
               local launcher="$target_app/Contents/MacOS/$executable_name"
               /bin/cat > "$launcher" <<LAUNCHER
             #!/bin/sh
+            # Self-heal stale compatibility.ini.
+            #
+            # Firefox stamps \$PROFILE/compatibility.ini with the bundle path that
+            # last opened the profile. If another Firefox (the base /Applications/Firefox.app
+            # or the in-browser profile switcher from another bundle) has touched
+            # this profile, our launch would silently exit because Firefox 137+
+            # treats the path mismatch as a version/install downgrade. Detect the
+            # mismatch up front, drop the stale compat, and launch with
+            # --first-startup so Firefox re-stamps the file with OUR path.
+            COMPAT="$PROFILES_DIR/$profile_dir/compatibility.ini"
+            EXPECTED="LastPlatformDir=$target_app/Contents/Resources"
+            if [ -f "\$COMPAT" ] && ! /usr/bin/grep -qxF "\$EXPECTED" "\$COMPAT"; then
+              /bin/rm -f "\$COMPAT"
+              exec "\$(dirname "\$0")/firefox" \\
+                --no-remote \\
+                --first-startup \\
+                --profile "$PROFILES_DIR/$profile_dir" \\
+                "\$@"
+            fi
+
             exec "\$(dirname "\$0")/firefox" \\
               --no-remote \\
               --profile "$PROFILES_DIR/$profile_dir" \\


### PR DESCRIPTION
Firefox 137+ stamps $PROFILE/compatibility.ini with the bundle path that
last opened it. When ANY other Firefox — the base /Applications/Firefox.app,
the sibling Firefox Personal.app via the in-browser profile switcher, or
Firefox's own "switch profile" UI — touches our profile, our subsequent
Firefox <Name>.app launch detects the path mismatch and silently exits
with code 0 (Firefox treats it as an install/version downgrade and
refuses to proceed without user interaction, which is impossible in our
command-line launch context).

This bit hard after debugging: we'd seen Telepatia.app stop launching
with zero output after any cross-bundle profile access. Delete-and-
rebuild doesn't fix it because the stale compat.ini is on the profile
side (under ~/Library/Application Support/Firefox/Profiles/), not the
.app bundle side. The only fix is to either avoid ever touching the
profile from another bundle (fragile) or detect the mismatch at launch
time.

The launcher now:
  1. Reads $PROFILE/compatibility.ini's LastPlatformDir
  2. If it matches our bundle's Resources path, normal fast-path exec
  3. If it doesn't, rm the stale compat + exec with --first-startup so
     Firefox re-stamps the file with OUR bundle

--first-startup triggers Firefox's post-install tasks (OS registration,
etc.) but does NOT force a welcome page — Firefox decides that from
separate state. Net effect: stale compat auto-recovers on next launch,
then subsequent launches hit the fast path.
