### PR TITLE
fix(firefox): per-profile MOZ_APP_REMOTINGNAME so URL events stop leaking between bundles

### DIFF
--- a/modules/browser/firefox/profile-apps.nix
+++ b/modules/browser/firefox/profile-apps.nix
@@ -289,6 +289,32 @@
               local launcher="$target_app/Contents/MacOS/$executable_name"
               /bin/cat > "$launcher" <<LAUNCHER
             #!/bin/sh
+            # MOZ_APP_REMOTINGNAME gives this profile a unique remoting name so
+            # its CFMessagePort (Mozilla_<name>_<profile>_RemoteWindow) and its
+            # /tmp/<name> startup mutex live in their own namespace, separated
+            # from every other profile bundle. Without this all Firefox
+            # processes share the literal name \`firefox\` and URL Apple Events
+            # delivered to one bundle leak into whichever process won the
+            # shared-namespace IPC race.
+            #
+            # We deliberately do NOT set MOZ_NEW_INSTANCE / pass --new-instance.
+            # That flag (the modern replacement for the now-stripped --no-remote)
+            # disables this Firefox's cross-process remote *client* so it cannot
+            # forward command lines to itself either. We still need same-profile
+            # forwarding so that \`open -b $bundle_id <url>\`, which macOS
+            # dispatches by spawning a fresh firefox with the URL on argv when
+            # the existing instance can't accept the Apple Event, forwards the
+            # URL via CFMessagePort to the running same-profile Firefox instead
+            # of failing on the profile lock with "A copy of Firefox is already
+            # open". With unique remoting names per profile the forwarding only
+            # ever resolves to a sibling of the same profile, so cross-bundle
+            # leakage is impossible.
+            #
+            # See:
+            #   toolkit/xre/nsAppRunner.cpp           — appRemotingName lookup
+            #   toolkit/components/remote/RemoteUtils.h — BuildClassName uses it
+            export MOZ_APP_REMOTINGNAME=$bundle_id
+
             # Self-heal stale compatibility.ini.
             #
             # Firefox stamps \$PROFILE/compatibility.ini with the bundle path that
@@ -303,14 +329,12 @@
             if [ -f "\$COMPAT" ] && ! /usr/bin/grep -qxF "\$EXPECTED" "\$COMPAT"; then
               /bin/rm -f "\$COMPAT"
               exec "\$(dirname "\$0")/firefox" \\
-                --no-remote \\
                 --first-startup \\
                 --profile "$PROFILES_DIR/$profile_dir" \\
                 "\$@"
             fi
 
             exec "\$(dirname "\$0")/firefox" \\
-              --no-remote \\
               --profile "$PROFILES_DIR/$profile_dir" \\
               "\$@"
             LAUNCHER


### PR DESCRIPTION
Firefox 150's cross-process remote service keys both its CFMessagePort
IPC channel and its /tmp/<name> startup mutex on (programName, profilePath).
programName is the literal string 'firefox' for all Firefox builds
regardless of CFBundleIdentifier (set via gAppData->remotingName, which
defaults to mAppData->name = 'firefox'), so our cloned per-profile bundles
all shared one IPC namespace. The visible symptom was that URL Apple
Events delivered to org.mozilla.firefox.telepatia would land in whichever
firefox process won the shared-namespace race — Personal in practice,
since it usually starts first.

The launcher script now exports MOZ_APP_REMOTINGNAME=$bundle_id at startup,
which Firefox's nsAppRunner.cpp picks up and uses in place of 'firefox'
for SetProgram + the BuildClassName CFMessagePort name + the startup
mutex path. With unique remoting names per profile the same-profile
forwarding (which is how 'open -b <bundle-id> <url>' actually delivers
URLs to a running Firefox: macOS spawns a fresh firefox process which
forwards command-line via CFMessagePort to the existing instance) only
ever resolves to a sibling of the same profile, so cross-bundle leakage
is impossible.

Also drops the legacy --no-remote flag from the launcher: Firefox 150
silently strips it in nsAppRunner.cpp (\`CheckArg("no-remote")\` with no
consumer) and the modern replacement --new-instance / MOZ_NEW_INSTANCE
disables this Firefox's remote *client* — preventing the same-profile
forwarding above from working and triggering 'A copy of Firefox is already
open' on the profile lock instead. We deliberately do NOT set either:
namespace separation alone is what we want.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
