### PR TITLE
feat(hammerspoon): generic extras loader for cross-module Lua snippets

### DIFF
--- a/modules/darwin/hammerspoon/init.lua
+++ b/modules/darwin/hammerspoon/init.lua
@@ -681,4 +681,28 @@ retain.configWatcher = hs.pathwatcher.new(os.getenv("HOME") .. "/.hammerspoon/",
 end)
 retain.configWatcher:start()
 
+-- ---------------------------------------------------------------------------
+-- Extras loader
+-- ---------------------------------------------------------------------------
+-- Other modules (e.g. modules/browser/finicky-firefox-router.nix) drop
+-- additional .lua snippets into ~/.hammerspoon/extras/ via home-manager.
+-- This loader runs each one in pcall so a single broken extra cannot break
+-- the rest of the config. Each snippet is responsible for its own retention
+-- (typically via a _G.__<name>Retain table — see init.lua's _G.__hsHyperRetain
+-- pattern).
+local extrasDir = os.getenv("HOME") .. "/.hammerspoon/extras"
+if hs.fs.attributes(extrasDir, "mode") == "directory" then
+  for f in hs.fs.dir(extrasDir) do
+    if f:match("%.lua$") then
+      local path = extrasDir .. "/" .. f
+      local ok, err = pcall(dofile, path)
+      if ok then
+        log("INIT", "Loaded extra: " .. f)
+      else
+        log("ERROR", "extras/" .. f .. ": " .. tostring(err))
+      end
+    end
+  end
+end
+
 log("INIT", "======== Hyper key ready ========")


### PR DESCRIPTION
Other modules can now extend hammerspoon by dropping .lua files into
~/.hammerspoon/extras/ (typically via home-manager's home.file). At
startup init.lua walks that directory and dofile()s each snippet under
pcall so a single broken extra cannot crash the whole config. Each
snippet owns its own retention via _G.__<name>Retain (same pattern as
init.lua's _G.__hsHyperRetain) since dofile()'d chunks don't share the
retain table local to init.lua.

Loads in dependency order zero (no other modules depend on init.lua state),
so extras can call hs.* APIs freely. INIT-level log lines record each
load + any pcall errors so failures show up in ~/.hammerspoon/hyper.log
instead of silently disappearing.

Used by modules/browser/finicky-firefox-router.nix in a follow-up commit
to install the http/https URL receiver that powers active-Firefox
routing.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
