### PR TITLE
chore(opencode): 1.15.10 follow-up

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,17 +120,16 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1778282525,
-        "narHash": "sha256-FuM5XQDDkOZC1F7D1S3mesWshEwdhDTBkBuEUV+J29g=",
+        "lastModified": 1779577307,
+        "narHash": "sha256-Yn5j6qChG5PadroydtyoFuvbNCAfuGqSxhZ1OtQ8Jiw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "be239533b25436c7d39ceadc19bb9b5fffc0d428",
+        "rev": "572971099e569a0d7269227cec50f53687b7e400",
         "type": "github"
       },
       "original": {
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "be239533b25436c7d39ceadc19bb9b5fffc0d428",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -30,12 +30,7 @@
     };
 
     homebrew-cask = {
-      # Pin to May 8, 2026: anything newer ships a broken `stremio` cask
-      # ("Only a single 'depends_on macos' is allowed" — see
-      # https://github.com/Homebrew/homebrew-cask/pull/264299 which was
-      # closed without merging the fix). Bump to HEAD once upstream
-      # repairs the cask.
-      url = "github:homebrew/homebrew-cask?rev=be239533b25436c7d39ceadc19bb9b5fffc0d428";
+      url = "github:homebrew/homebrew-cask";
       flake = false;
     };
 

--- a/modules/dev/opencode-manager/opencode-manager.nix
+++ b/modules/dev/opencode-manager/opencode-manager.nix
@@ -129,7 +129,7 @@ let
       fi
       [[ -z "$PANE_PATH" ]] && exit 1
 
-      OPENCODE_DB="$HOME/.local/share/opencode/opencode-local.db"
+      OPENCODE_DB="$HOME/.local/share/opencode/opencode.db"
       [[ ! -f "$OPENCODE_DB" ]] && exit 1
 
       GIT_ROOT=$(tmux-git-root-path "$PANE_PATH")

--- a/modules/dev/opencode-manager/scripts/oc-sync-sid.sh
+++ b/modules/dev/opencode-manager/scripts/oc-sync-sid.sh
@@ -25,7 +25,7 @@ fi
 
 EXTRACTED="${TITLE#OC | }"
 
-DB="$HOME/.local/share/opencode/opencode-local.db"
+DB="$HOME/.local/share/opencode/opencode.db"
 [[ ! -f "$DB" ]] && exit 0
 
 SAFE=$(printf '%s' "$EXTRACTED" | sed "s/'/''/g")

--- a/modules/dev/opencode-manager/scripts/opencode-manager.sh
+++ b/modules/dev/opencode-manager/scripts/opencode-manager.sh
@@ -7,7 +7,7 @@ set -eu
 
 NOTIFY_FILE="${TMUX_NOTIFY_FILE:-/tmp/tmux-notifications.json}"
 LOCK_FILE="${NOTIFY_FILE}.lock"
-OPENCODE_DB="${HOME}/.local/share/opencode/opencode-local.db"
+OPENCODE_DB="${HOME}/.local/share/opencode/opencode.db"
 TRIGGER_FILE="/tmp/tmux-opencode-refresh"
 
 _init_file() {

--- a/modules/dev/opencode/patches/relax-bun-version-check.patch
+++ b/modules/dev/opencode/patches/relax-bun-version-check.patch
@@ -2,17 +2,17 @@ Relax the bun version check in `opencode generate` build script.
 
 Upstream pins `bun@1.3.14` via the root `packageManager` field and the
 script enforces `^1.3.14` at the start of every build.  Nixpkgs currently
-ships `bun@1.3.13` (the previous opencode rev's pin) — a single patch
-version behind upstream — so the strict caret range fails the build
-without offering any actual incompatibility (bun's 1.3.x line is
-backwards compatible across patch versions).
+ships `bun@1.3.11` — a few patch versions behind upstream — so the strict
+caret range fails the build without offering any actual incompatibility
+(bun's 1.3.x line is backwards compatible across patch versions).
 
 Upstream's own comment above the version constraint already reads
 "relax version requirement", suggesting the intent is to be permissive.
 This patch widens the range from `^${expectedBunVersion}` (caret) to
-`>=1.3.13` (tilde-equivalent open-ended), letting the build pass with
+`>=1.3.11` (tilde-equivalent open-ended), letting the build pass with
 the current nixpkgs bun while still rejecting wildly out-of-date bun
-versions.  Drop this patch once nixpkgs ships bun 1.3.14+.
+versions.  Bump the lower bound as nixpkgs catches up; drop this patch
+once nixpkgs ships bun 1.3.14+.
 
 diff --git a/packages/script/src/index.ts b/packages/script/src/index.ts
 --- a/packages/script/src/index.ts
@@ -22,7 +22,7 @@ diff --git a/packages/script/src/index.ts b/packages/script/src/index.ts
  
  // relax version requirement
 -const expectedBunVersionRange = `^${expectedBunVersion}`
-+const expectedBunVersionRange = `>=1.3.13`
++const expectedBunVersionRange = `>=1.3.11`
  
  if (!semver.satisfies(process.versions.bun, expectedBunVersionRange)) {
    throw new Error(`This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`)

--- a/modules/dev/opencode/server.nix
+++ b/modules/dev/opencode/server.nix
@@ -83,7 +83,7 @@ let
         _PANE="''${TMUX_PANE:-}"
 
         if [[ -n "$_PANE" ]]; then
-          _DB="$HOME/.local/share/opencode/opencode-local.db"
+          _DB="$HOME/.local/share/opencode/opencode.db"
 
           # Parse --session and --fork from args
           _oc_sid="" _oc_fork=0 _prev=""


### PR DESCRIPTION
Follow-up to #464 (opencode 1.15.10 upgrade).

## What changed

### opencode-manager + server: point at the new DB path

opencode v1.15.10 moved the SQLite database from `opencode-local.db` (channel-suffixed) to `opencode.db` for the `latest`/`beta`/`prod` installation channels. Every hardcoded path that referenced the old name is updated:

- `modules/dev/opencode-manager/opencode-manager.nix`
- `modules/dev/opencode-manager/scripts/oc-sync-sid.sh`
- `modules/dev/opencode-manager/scripts/opencode-manager.sh`
- `modules/dev/opencode/server.nix`

Without this, the manager and the server wrapper silently no-op on systems that have already migrated.

### Refresh bun version-check patch

Lower the patch's accepted bun range from `>=1.3.13` to `>=1.3.11` to match the current nixpkgs bun. Drop the patch once nixpkgs ships 1.3.14+.

### Unpin homebrew-cask

The broken `stremio` cask that forced the May 8 pin has been fixed upstream — let homebrew-cask track HEAD again.

## Verification

- `statix check .` clean
- `nixfmt --check` clean on modified `.nix` files
- `shellcheck` clean on modified shell scripts
