### PR TITLE
fix(brew): pin brew-src to 5.1.13 for cask OS-dependency fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1774235677,
-        "narHash": "sha256-0ryNYmzDAeRlrzPTAgmzGH/Cgc8iv/LBN6jWGUANvIk=",
+        "lastModified": 1779378574,
+        "narHash": "sha256-1NGjx2DBvqPYMMwFnth0dHeCJiHG+LG7EWefB1WmJls=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "894a3d23ac0c8aaf561b9874b528b9cb2e839201",
+        "rev": "d8deaca5574faf79a27f110caedc9e153709e628",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.1",
+        "ref": "5.1.13",
         "repo": "brew",
         "type": "github"
       }
@@ -136,11 +136,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1776568637,
-        "narHash": "sha256-uVfjjBMfCMrkc/R2pC72uXhcaULyzg5nXXO9EKmX5pE=",
+        "lastModified": 1779582969,
+        "narHash": "sha256-hvyHNy2JFXLUHCIDve2zhQOqrIYTyTnxc62uvJe7Ov4=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "8905c82a3c0d2e6a0f898b9f50b36453f4a8f7b2",
+        "rev": "0cbd19f57c213d4b7f9bc74c64410143ecb7a29e",
         "type": "github"
       },
       "original": {
@@ -167,14 +167,16 @@
     },
     "nix-homebrew": {
       "inputs": {
-        "brew-src": "brew-src"
+        "brew-src": [
+          "brew-src"
+        ]
       },
       "locked": {
-        "lastModified": 1774720267,
-        "narHash": "sha256-YYftFe8jyfpQI649yfr0E+dqEXE2jznZNcYvy/lKV1U=",
+        "lastModified": 1778851564,
+        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "a7760a3a83f7609f742861afb5732210fdc437ed",
+        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
         "type": "github"
       },
       "original": {
@@ -222,6 +224,7 @@
     },
     "root": {
       "inputs": {
+        "brew-src": "brew-src",
         "darwin": "darwin",
         "direnv-instant": "direnv-instant",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,16 @@
 
     nix-homebrew = {
       url = "github:zhaofengli/nix-homebrew";
+      inputs.brew-src.follows = "brew-src";
+    };
+
+    # Pin brew to a version that includes the cask OS-dependency regression fix
+    # (https://github.com/Homebrew/brew/pull/22261), required for casks like
+    # stremio and iina that combine `on_arm`/`on_intel` macOS deps with a
+    # top-level `depends_on :macos`.
+    brew-src = {
+      url = "github:Homebrew/brew/5.1.13";
+      flake = false;
     };
 
     homebrew-core = {


### PR DESCRIPTION
## Problem

\`brew bundle\` fails during \`darwin-rebuild\` with two cascading cask DSL errors:

\`\`\`
Error: Cask 'yubico-authenticator' is unreadable: wrong number of arguments (given 1, expected 0)
Error: Cask 'stremio' definition is invalid: Only a single 'depends_on macos' is allowed.
\`\`\`

## Root cause

The flake's \`homebrew-cask\` input tracks HEAD (currently 2026-05-23) but \`brew-src\` — pulled transitively via \`nix-homebrew\` — was pinned to a commit from 2026-03-23. Casks at HEAD use a DSL pattern (combining \`on_arm\`/\`on_intel\` macOS deps with a top-level \`depends_on :macos\`) that the older brew binary doesn't accept.

## Fix

Promote \`brew-src\` to a top-level input pinned to the \`5.1.13\` tag, and have \`nix-homebrew\` follow it. 5.1.13 includes [Homebrew/brew#22261](https://github.com/Homebrew/brew/pull/22261) ("Fix cask OS dependency regressions"), which resolves both errors.

The version comment in [flake.nix](../blob/fix/brew-cask-os-dependency/flake.nix) links back to the upstream PR so future bumps know why this pin exists.

## Verification

- \`brew info --cask stremio\` → readable (previously errored)
- \`sudo darwin-rebuild switch --flake .#m1\` → succeeds end-to-end; Stremio.app code-signed during activation
- yubico-authenticator, stremio, iina all install cleanly

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)