### PR TITLE
fix(opencode): switch title and CLI agents from unauthed minimax to claude-haiku

### DIFF
--- a/modules/dev/lazygit.nix
+++ b/modules/dev/lazygit.nix
@@ -10,16 +10,16 @@ mkUserModule {
           {
             key = "<c-a>";
             context = "files";
-            command = ''opencode run -m "opencode/minimax-m2.5-free" "Look at the staged changes and create a commit following conventional commit conventions. Just commit directly."'';
+            command = ''opencode run -m "anthropic/claude-haiku-4-5" "Look at the staged changes and create a commit following conventional commit conventions. Just commit directly."'';
             output = "terminal";
             description = "Generate commit with OpenCode";
           }
           {
             key = "H";
             context = "global";
-            command = ''opencode run -m "opencode/minimax-m2.5-free" "{{.Form.Prompt}}"'';
+            command = ''opencode run -m "anthropic/claude-haiku-4-5" "{{.Form.Prompt}}"'';
             output = "terminal";
-            description = "AI help (minimax)";
+            description = "AI help (haiku)";
             prompts = [
               {
                 type = "input";

--- a/modules/dev/linear.nix
+++ b/modules/dev/linear.nix
@@ -452,7 +452,7 @@ mkUserModule {
                                         set -l promptfile (mktemp)
                                         printf '%s' "$prompt" > $promptfile
                                         gum spin --spinner dot --title "Generating issue with AI..." -- \
-                                          sh -c 'opencode run -m "opencode/minimax-m2.5-free" "$(cat "$1")" > "$2" 2> "$3"' _ "$promptfile" "$tmpfile" "$errfile"
+                                          sh -c 'opencode run -m "anthropic/claude-haiku-4-5" "$(cat "$1")" > "$2" 2> "$3"' _ "$promptfile" "$tmpfile" "$errfile"
                                         set -l ai_exit $status
 
                                         set -l result (cat $tmpfile)
@@ -638,7 +638,7 @@ mkUserModule {
                                             printf 'You are refining a Linear issue. Current issue:\n%s\n\nRequested change: %s\n\nReturn ONLY the updated raw JSON object (no markdown fences, no commentary).\nSame schema: {"title": string, "description": string, "priority": int, "labels": string[], "project_hint": string|null, "assign_to_me": boolean}\nKeep fields unchanged unless the instruction implies a change.' "$current_json" "$instruction" > $refine_file
 
                                             gum spin --spinner dot --title "Refining with AI..." -- \
-                                              sh -c 'opencode run -m "opencode/minimax-m2.5-free" "$(cat "$1")" > "$2" 2> "$3"' _ "$refine_file" "$r_out" "$r_err"
+                                              sh -c 'opencode run -m "anthropic/claude-haiku-4-5" "$(cat "$1")" > "$2" 2> "$3"' _ "$refine_file" "$r_out" "$r_err"
                                             set -l r_exit $status
 
                                             set -l r_result (cat $r_out)

--- a/modules/dev/opencode/opencode.nix
+++ b/modules/dev/opencode/opencode.nix
@@ -90,7 +90,7 @@ mkUserModule {
           };
           agent = {
             title = {
-              model = "opencode/minimax-m2.5-free";
+              model = "anthropic/claude-haiku-4-5";
             };
           };
 


### PR DESCRIPTION
## Problem

Every newly created opencode parent session has been stuck on the default title `New session - <iso>` for days. The opencode-manager TUI / session list shows nothing but generic timestamps for parent sessions.

## Root cause

The title agent was configured to use `opencode/minimax-m2.5-free`:

```nix
agent = {
  title = {
    model = "opencode/minimax-m2.5-free";
  };
};
```

That model lives under the `opencode` (Zen) provider, but `~/.local/share/opencode/auth.json` only contains `anthropic` — no auth for the `opencode` provider. So `provider.getModel("opencode", "minimax-m2.5-free")` throws `ModelNotFoundError` every time the title agent runs.

The failure is invisible because the title fiber in [`session/prompt.ts`](https://github.com/sst/opencode/blob/dev/packages/opencode/src/session/prompt.ts) is wrapped in `Effect.ignore`. The `elog.error("failed to generate title", ...)` only covers the final `setTitle` call — earlier failures (agent resolution, model lookup, LLM streaming) propagate up and get swallowed silently. No log line, no visible error.

Subagent sessions kept working because their titles are set explicitly by the `task` tool at creation time, bypassing the AI title path entirely.

The same broken alias was also used in:
- `lazygit` commit-gen + AI help commands
- `linear` prompt + refine runners

All three would have silently failed the same way the moment they were invoked.

## Fix

Switch every reference from `opencode/minimax-m2.5-free` to `anthropic/claude-haiku-4-5`, which uses the provider already in `auth.json`.

| File | Change |
|---|---|
| `modules/dev/opencode/opencode.nix` | title agent model |
| `modules/dev/lazygit.nix` | commit-gen + AI help model + description text |
| `modules/dev/linear.nix` | prompt + refine runner model |

## Verification

- `statix` clean across all three files
- `nixfmt` clean across all three files
- Manually verified after `darwin-rebuild switch`: new sessions now get meaningful Haiku-generated titles
- No remaining `minimax` references in any `.nix` file outside the vendored `opencode/` source tree

## Note on existing sessions

Title generation only fires on `step === 1` of a fresh session ([prompt.ts:1278](https://github.com/sst/opencode/blob/dev/packages/opencode/src/session/prompt.ts)), so the backlog of `New session - ...` rows in the DB will not retroactively get titled. This is fine — only new sessions need to work.

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
