### PR TITLE
fix: clean up darwin-rebuild warnings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776562531,
-        "narHash": "sha256-Lh5Ns9DI67E+lSMOCGK0S+mFPy0mz0yOGiJTUXiR9JI=",
+        "lastModified": 1779580960,
+        "narHash": "sha256-/EG2rRahtxdoKKzGPGqaymVB96kBBYhygatEAbsoqaM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b56ad02dc643808b8af6d5f3ff179e2ce9593f4",
+        "rev": "6e92bf094d45bc33d754e2b0f75d9ca1827cc363",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
           buildInputs = with pkgs; [
             nixd
             statix
-            nixfmt-rfc-style
+            nixfmt
 
             shellcheck
 

--- a/lib/mkUser.nix
+++ b/lib/mkUser.nix
@@ -72,13 +72,20 @@ in
             linux = "/home/${name}";
           };
 
-          home-manager.users.${name}.home = {
-            username = name;
-            homeDirectory = forPlatform {
-              darwin = "/Users/${name}";
-              linux = "/home/${name}";
+          home-manager.users.${name} = {
+            home = {
+              username = name;
+              homeDirectory = forPlatform {
+                darwin = "/Users/${name}";
+                linux = "/home/${name}";
+              };
+              inherit stateVersion;
             };
-            inherit stateVersion;
+
+            # On darwin with stateVersion >= 26.05, programs.man.package
+            # defaults to null (macOS provides its own man). Disable cache
+            # generation explicitly so HM doesn't warn about a no-op.
+            programs.man.generateCaches = false;
           };
         }
       )

--- a/modules/editor/nvim/lsp.nix
+++ b/modules/editor/nvim/lsp.nix
@@ -46,7 +46,7 @@ in
 
       # Formatters & linters
       stylua
-      nixfmt-rfc-style
+      nixfmt
       prettierd
       black
       gofumpt


### PR DESCRIPTION
Fixes the warnings that appeared during `sudo darwin-rebuild switch --flake .#m1`.

## Changes

1. **`chore(deps): bump home-manager to 2026-05-24`** — `flake.lock`
2. **`fix(nix): rename deprecated nixfmt-rfc-style to nixfmt`** — `flake.nix`, `modules/editor/nvim/lsp.nix`
   - Silences: `evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.`
3. **`fix(home): disable programs.man.generateCaches on darwin`** — `lib/mkUser.nix`
   - Silences: `trace: warning: <user> profile: programs.man.generateCaches has no effect when programs.man.package is null`
   - On darwin with `home.stateVersion >= 26.05`, HM defaults `programs.man.package` to `null` because macOS provides its own man. With `generateCaches = true` (from somewhere upstream) and `package = null`, HM warns the cache generation is a no-op. Disable it explicitly in `mkUser` so it applies to every user.

## Verification

`sudo darwin-rebuild switch --flake .#m1` after these changes leaves only:
- `warning: Git tree '/Users/fernando/nix-config' is dirty` — local-only, goes away on commit
- `warning: 'install' is a deprecated alias for 'add'` — emitted by HM's activation script (`profile install` is hardcoded in upstream `modules/home-environment.nix`, present on both pinned and master); not fixable from our side without patching home-manager

---

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
