### PR TITLE
feat(nalum): add hermes-agent workspace module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,6 +81,52 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix_2",
+        "uv2nix": "uv2nix_2"
+      },
+      "locked": {
+        "lastModified": 1779585557,
+        "narHash": "sha256-1+/qntvgD6kGWz1g0NZpdV8oynarybnU2vWDM1mD1EE=",
+        "owner": "nousresearch",
+        "repo": "hermes-agent",
+        "rev": "72ff3e909c73b625ee244ab5ea3d0608ee85dcf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nousresearch",
+        "repo": "hermes-agent",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -201,6 +247,27 @@
         "type": "github"
       }
     },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
     "opencode": {
       "inputs": {
         "nixpkgs": [
@@ -222,11 +289,100 @@
         "type": "github"
       }
     },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769936401,
+        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "uv2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771518446,
+        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "brew-src": "brew-src",
         "darwin": "darwin",
         "direnv-instant": "direnv-instant",
+        "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "homebrew-bundle": "homebrew-bundle",
         "homebrew-cask": "homebrew-cask",
@@ -289,6 +445,55 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-build-systems",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770770348,
+        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": "pyproject-nix_3"
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,11 @@
       url = "github:anomalyco/opencode?rev=7fe7b9f258e36ad9f9acded20c5a9df201da19d5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    hermes-agent = {
+      url = "github:nousresearch/hermes-agent";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/modules/dev/nalum.nix
+++ b/modules/dev/nalum.nix
@@ -1,0 +1,44 @@
+# nalum — personal Hermes Agent workspace.
+#
+# Installs the Hermes Agent CLI and points HERMES_HOME at ~/nalum, where
+# every personal bit lives (SOUL.md, AGENTS.md, config.yaml, .env, skills/,
+# plugins/, dashboard-themes/, etc.) — version-controlled in its own
+# private repo, never in this public nix-config.
+#
+# The directory-existence safety check runs at darwin-rebuild activation
+# time (not eval time): an absent ~/nalum surfaces as a loud warning during
+# the switch, but doesn't block the rebuild. Eval-time gating would require
+# `--impure`, which we avoid so plain `darwin-rebuild switch --flake .#m1`
+# keeps working.
+{
+  mkUserModule,
+  pkgs,
+  inputs,
+  ...
+}:
+mkUserModule {
+  name = "nalum";
+
+  home =
+    { lib, username, ... }:
+    let
+      nalumDir = "/Users/${username}/nalum";
+    in
+    {
+      home = {
+        packages = [ inputs.hermes-agent.packages.${pkgs.system}.default ];
+        sessionVariables.HERMES_HOME = nalumDir;
+        activation.nalumCheck = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          if [ ! -d "${nalumDir}" ]; then
+            echo ""
+            echo "  ⚠ nalum: ${nalumDir} does not exist."
+            echo "    Hermes will auto-create it on first run, but for declarative"
+            echo "    tracking initialize it as a private git repo first:"
+            echo ""
+            echo "      mkdir -p ${nalumDir} && cd ${nalumDir} && git init"
+            echo ""
+          fi
+        '';
+      };
+    };
+}

--- a/modules/users/m1-fernando.nix
+++ b/modules/users/m1-fernando.nix
@@ -43,6 +43,7 @@ mkUser {
   opencode-manager.enable = true;
   # rtk.enable = true;
   ollama.enable = true;
+  nalum.enable = true;
   linear.enable = true;
 
   # Editors


### PR DESCRIPTION
## What

Adds a \`nalum\` user module that installs [Nous Research's Hermes Agent](https://github.com/nousresearch/hermes-agent) and points \`HERMES_HOME\` at \`~/nalum\`.

## Why

\`~/nalum\` lives as a **separate private repo** holding every personal Hermes bit — \`SOUL.md\`, \`AGENTS.md\`, \`config.yaml\`, \`.env\`, \`skills/\`, \`plugins/\`, \`dashboard-themes/\`, custom MCP servers, cron jobs, prompt templates, etc. This public nix-config stays clean: it owns the **install + \`HERMES_HOME\` wiring only**, never the personal values.

Hermes' plugin system (skills, dashboard themes/plugins, memory providers, context engines, custom platforms, image-gen backends, model providers, gateway hooks, MCP servers) makes \`~/nalum\` the natural extension point for all future personal work — no upstream forking needed.

## Design note: activation-time check, not eval-time

The directory-existence safety check runs at **activation time**, not eval time. Flakes' pure eval would require \`--impure\` to gate on \`builtins.pathExists\` for paths outside the flake source — which would break the standard \`darwin-rebuild switch --flake .#m1\` workflow.

The activation script emits a visible warning during \`darwin-rebuild\` if \`~/nalum\` is missing, with the exact bootstrap command, but doesn't block the rebuild.

## Files

- \`flake.nix\` — adds \`hermes-agent\` input following \`nixpkgs\`
- \`modules/dev/nalum.nix\` — new module (installs \`hermes-agent-0.14.0\`, sets \`HERMES_HOME\`, activation warning)
- \`modules/users/m1-fernando.nix\` — \`nalum.enable = true\` next to \`ollama.enable\`
- \`flake.lock\` — input pin

## Verification

- \`nixfmt --check\` ✓
- \`statix check\` ✓
- \`nix eval .#darwinConfigurations.m1.config.home-manager.users.fernando.home.sessionVariables.HERMES_HOME\` → \`/Users/fernando/nalum\`
- \`hermes-agent-0.14.0\` resolves in fernando's home packages

## Post-merge

\`\`\`bash
sudo darwin-rebuild switch --flake .#m1
echo $HERMES_HOME   # /Users/fernando/nalum
which hermes
hermes doctor

# Initialize ~/nalum as the private workspace repo
cd ~/nalum && git init
hermes setup        # writes config.yaml, prompts for API keys → .env
\`\`\`