### PR TITLE
fix(nalum): use bare-string activation form

### DIFF
--- a/modules/dev/nalum.nix
+++ b/modules/dev/nalum.nix
@@ -20,7 +20,7 @@ mkUserModule {
   name = "nalum";
 
   home =
-    { lib, username, ... }:
+    { username, ... }:
     let
       nalumDir = "/Users/${username}/nalum";
     in
@@ -28,7 +28,7 @@ mkUserModule {
       home = {
         packages = [ inputs.hermes-agent.packages.${pkgs.system}.default ];
         sessionVariables.HERMES_HOME = nalumDir;
-        activation.nalumCheck = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        activation.nalumCheck = ''
           if [ ! -d "${nalumDir}" ]; then
             echo ""
             echo "  ⚠ nalum: ${nalumDir} does not exist."


### PR DESCRIPTION
## Problem

After #469 landed, \`darwin-rebuild\` failed with:

\`\`\`
error: attribute 'hm' missing
  at modules/dev/nalum.nix:31:33:
    activation.nalumCheck = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
\`\`\`

\`lib.hm.dag.entryAfter\` is unavailable here: \`mkUserModule\` passes nixpkgs.lib to the home function, not home-manager's extended lib (which adds \`lib.hm\`).

## Fix

Match the patterns already established by two existing modules in this repo:

- [\`modules/browser/finicky-firefox-router.nix\`](https://github.com/fersilva16/nix-config/blob/main/modules/browser/finicky-firefox-router.nix) — bare-string form
- [\`modules/browser/firefox/profile-apps.nix\`](https://github.com/fersilva16/nix-config/blob/main/modules/browser/firefox/profile-apps.nix) — raw DAG attrset (\`{ after = [...]; before = []; data = ''…''; }\`)

The \`nalumCheck\` script doesn't depend on home-manager file writes, so the bare-string form is the cleanest match.

## Verification

- \`nixfmt --check\` ✓
- \`statix check\` ✓
- \`nix eval .#darwinConfigurations.m1.system.outPath\` → \`/nix/store/mh5hvkrdnwk8w1k72979sbywkbin8ypn-darwin-system-26.05.06648f4\` ✓ (previously errored)

## History note

This same fix landed briefly as \`e89c4b5\` directly on \`main\` (workflow violation on my end — didn't verify the branch state after #469 was merged). \`a7f80de\` reverted that, and this PR re-applies the fix through the proper PR workflow.