### PR TITLE
feat(lib): add casks field to mkUserModule and migrate cask modules

### DIFF
--- a/lib/mkUserModule.nix
+++ b/lib/mkUserModule.nix
@@ -11,7 +11,12 @@
 #   name:         Module name. Creates `modules.users.<user>.<name>.enable` option.
 #
 #   system:       (optional) System-level config applied once when any user enables
-#                 the module. Always a static attrset.
+#                 the module. Always a static attrset. Must be cross-platform —
+#                 darwin-only options need a forPlatform { darwin = ...; } wrap.
+#
+#   casks:        (optional) Homebrew casks to install on darwin when any user
+#                 enables the module. Sugar for the common GUI-app case; on
+#                 linux this is structurally absent (no homebrew options there).
 #
 #   home:         (optional) Per-user home-manager config. Can be an attrset (static)
 #                 or a function ({ cfg, lib, username, userCfg } -> attrset) when
@@ -57,6 +62,7 @@
 {
   name,
   system ? { },
+  casks ? [ ],
   home ? { },
   user ? { },
   extraOptions ? { },
@@ -72,7 +78,12 @@ in
 {
   imports = [
     (
-      { config, lib, ... }:
+      {
+        config,
+        lib,
+        forPlatform,
+        ...
+      }:
       let
         enabledUsers = lib.filterAttrs (_: u: u.${name}.enable) config.modules.users;
         hasEnabled = enabledUsers != { };
@@ -118,6 +129,15 @@ in
         config = lib.mkIf hasEnabled (
           lib.mkMerge (
             [ system ]
+
+            # casks: darwin-only sugar. On linux the homebrew option tree
+            # doesn't exist, so the key must be structurally absent — which
+            # forPlatform guarantees ({} on linux).
+            ++ lib.optional (casks != [ ]) (forPlatform {
+              darwin = {
+                homebrew.casks = casks;
+              };
+            })
 
             # Part system configs: applied once when any enabled user has the part enabled
             ++ lib.optionals hasParts (

--- a/modules/browser/arc.nix
+++ b/modules/browser/arc.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "arc";
-  system.homebrew.casks = [ "arc" ];
+  casks = [ "arc" ];
 }

--- a/modules/browser/chrome.nix
+++ b/modules/browser/chrome.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "chrome";
-  system.homebrew.casks = [ "google-chrome" ];
+  casks = [ "google-chrome" ];
 }

--- a/modules/browser/finicky.nix
+++ b/modules/browser/finicky.nix
@@ -139,7 +139,7 @@ mkUserModule {
     };
   };
 
-  system.homebrew.casks = [ "finicky" ];
+  casks = [ "finicky" ];
 
   home =
     { cfg, lib, ... }:

--- a/modules/browser/firefox.nix
+++ b/modules/browser/firefox.nix
@@ -5,5 +5,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "firefox";
-  system.homebrew.casks = [ "firefox" ];
+  casks = [ "firefox" ];
 }

--- a/modules/browser/zen.nix
+++ b/modules/browser/zen.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "zen";
-  system.homebrew.casks = [ "zen-browser" ];
+  casks = [ "zen-browser" ];
 }

--- a/modules/chat/discord.nix
+++ b/modules/chat/discord.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "discord";
-  system.homebrew.casks = [ "discord" ];
+  casks = [ "discord" ];
 }

--- a/modules/chat/slack.nix
+++ b/modules/chat/slack.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "slack";
-  system.homebrew.casks = [ "slack" ];
+  casks = [ "slack" ];
 }

--- a/modules/chat/teams.nix
+++ b/modules/chat/teams.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "teams";
-  system.homebrew.casks = [ "microsoft-teams" ];
+  casks = [ "microsoft-teams" ];
 }

--- a/modules/chat/telegram.nix
+++ b/modules/chat/telegram.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "telegram";
-  system.homebrew.casks = [ "telegram" ];
+  casks = [ "telegram" ];
 }

--- a/modules/chat/whatsapp.nix
+++ b/modules/chat/whatsapp.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "whatsapp";
-  system.homebrew.casks = [ "whatsapp" ];
+  casks = [ "whatsapp" ];
 }

--- a/modules/chat/zoom.nix
+++ b/modules/chat/zoom.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "zoom";
-  system.homebrew.casks = [ "zoom" ];
+  casks = [ "zoom" ];
 }

--- a/modules/cli/chrome-cli.nix
+++ b/modules/cli/chrome-cli.nix
@@ -1,7 +1,14 @@
-{ mkUserModule, lib, ... }:
+{
+  mkUserModule,
+  forPlatform,
+  lib,
+  ...
+}:
 mkUserModule {
   name = "chrome-cli";
-  system.homebrew.brews = [ "chrome-cli" ];
+  system = forPlatform {
+    darwin.homebrew.brews = [ "chrome-cli" ];
+  };
   home =
     { userCfg, ... }:
     {

--- a/modules/dev/claude.nix
+++ b/modules/dev/claude.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "claude";
-  system.homebrew.casks = [ "claude" ];
+  casks = [ "claude" ];
 }

--- a/modules/dev/dbeaver.nix
+++ b/modules/dev/dbeaver.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "dbeaver";
-  system.homebrew.casks = [ "dbeaver-community" ];
+  casks = [ "dbeaver-community" ];
 }

--- a/modules/dev/linear.nix
+++ b/modules/dev/linear.nix
@@ -41,7 +41,7 @@ let
 in
 mkUserModule {
   name = "linear";
-  system.homebrew.casks = [ "linear" ];
+  casks = [ "linear" ];
   home =
     { userCfg, ... }:
     {

--- a/modules/dev/ngrok.nix
+++ b/modules/dev/ngrok.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "ngrok";
-  system.homebrew.casks = [ "ngrok" ];
+  casks = [ "ngrok" ];
 }

--- a/modules/dev/opencode-desktop.nix
+++ b/modules/dev/opencode-desktop.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "opencode-desktop";
-  system.homebrew.casks = [ "opencode-desktop" ];
+  casks = [ "opencode-desktop" ];
 }

--- a/modules/dev/orbstack.nix
+++ b/modules/dev/orbstack.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "orbstack";
-  system.homebrew.casks = [ "orbstack" ];
+  casks = [ "orbstack" ];
 }

--- a/modules/dev/postman.nix
+++ b/modules/dev/postman.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "postman";
-  system.homebrew.casks = [ "postman" ];
+  casks = [ "postman" ];
 }

--- a/modules/dev/rtk.nix
+++ b/modules/dev/rtk.nix
@@ -1,7 +1,9 @@
-{ mkUserModule, ... }:
+{ mkUserModule, forPlatform, ... }:
 mkUserModule {
   name = "rtk";
-  system.homebrew.brews = [ "rtk" ];
+  system = forPlatform {
+    darwin.homebrew.brews = [ "rtk" ];
+  };
   home = {
     home.file = {
       # Claude Code hook: rewrites bash commands to use rtk for token savings.

--- a/modules/dev/studio-3t.nix
+++ b/modules/dev/studio-3t.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "studio-3t";
-  system.homebrew.casks = [ "studio-3t-community" ];
+  casks = [ "studio-3t-community" ];
 }

--- a/modules/editor/android-studio.nix
+++ b/modules/editor/android-studio.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "android-studio";
-  system.homebrew.casks = [ "android-studio" ];
+  casks = [ "android-studio" ];
 }

--- a/modules/editor/conductor.nix
+++ b/modules/editor/conductor.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "conductor";
-  system.homebrew.casks = [ "conductor" ];
+  casks = [ "conductor" ];
 }

--- a/modules/editor/cursor.nix
+++ b/modules/editor/cursor.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "cursor";
-  system.homebrew.casks = [ "cursor" ];
+  casks = [ "cursor" ];
 }

--- a/modules/editor/intellij.nix
+++ b/modules/editor/intellij.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "intellij";
-  system.homebrew.casks = [ "intellij-idea-ce" ];
+  casks = [ "intellij-idea-ce" ];
 }

--- a/modules/games/prismlauncher.nix
+++ b/modules/games/prismlauncher.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "prismlauncher";
-  system.homebrew.casks = [ "prismlauncher" ];
+  casks = [ "prismlauncher" ];
 }

--- a/modules/games/sony.nix
+++ b/modules/games/sony.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "sony";
-  system.homebrew.casks = [ "sony-ps-remote-play" ];
+  casks = [ "sony-ps-remote-play" ];
 }

--- a/modules/games/steam.nix
+++ b/modules/games/steam.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "steam";
-  system.homebrew.casks = [ "steam" ];
+  casks = [ "steam" ];
 }

--- a/modules/media/affinity.nix
+++ b/modules/media/affinity.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "affinity";
-  system.homebrew.casks = [ "affinity" ];
+  casks = [ "affinity" ];
 }

--- a/modules/media/iina.nix
+++ b/modules/media/iina.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "iina";
-  system.homebrew.casks = [ "iina" ];
+  casks = [ "iina" ];
 }

--- a/modules/media/spotify.nix
+++ b/modules/media/spotify.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "spotify";
-  system.homebrew.casks = [ "spotify" ];
+  casks = [ "spotify" ];
 }

--- a/modules/media/stremio.nix
+++ b/modules/media/stremio.nix
@@ -1,12 +1,13 @@
-{ mkUserModule, ... }:
+{ mkUserModule, forPlatform, ... }:
 mkUserModule {
   name = "stremio";
-  system = {
-    homebrew.casks = [ "stremio" ];
-
-    system.activationScripts.postActivation.text = ''
-      sudo codesign --force --deep --sign - /Applications/Stremio.app
-      sudo xattr -rd com.apple.quarantine /Applications/Stremio.app
-    '';
+  casks = [ "stremio" ];
+  system = forPlatform {
+    darwin = {
+      system.activationScripts.postActivation.text = ''
+        sudo codesign --force --deep --sign - /Applications/Stremio.app
+        sudo xattr -rd com.apple.quarantine /Applications/Stremio.app
+      '';
+    };
   };
 }

--- a/modules/networking/cloudflare-warp.nix
+++ b/modules/networking/cloudflare-warp.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "cloudflare-warp";
-  system.homebrew.casks = [ "cloudflare-warp" ];
+  casks = [ "cloudflare-warp" ];
 }

--- a/modules/networking/pritunl.nix
+++ b/modules/networking/pritunl.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "pritunl";
-  system.homebrew.casks = [ "pritunl" ];
+  casks = [ "pritunl" ];
 }

--- a/modules/networking/tailscale.nix
+++ b/modules/networking/tailscale.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "tailscale";
-  system.homebrew.casks = [ "tailscale-app" ];
+  casks = [ "tailscale-app" ];
 }

--- a/modules/productivity/anki.nix
+++ b/modules/productivity/anki.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "anki";
-  system.homebrew.casks = [ "anki" ];
+  casks = [ "anki" ];
 }

--- a/modules/productivity/anytype.nix
+++ b/modules/productivity/anytype.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "anytype";
-  system.homebrew.casks = [ "anytype" ];
+  casks = [ "anytype" ];
 }

--- a/modules/productivity/calibre.nix
+++ b/modules/productivity/calibre.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "calibre";
-  system.homebrew.casks = [ "calibre" ];
+  casks = [ "calibre" ];
 }

--- a/modules/productivity/cold-turkey-blocker.nix
+++ b/modules/productivity/cold-turkey-blocker.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "cold-turkey-blocker";
-  system.homebrew.casks = [ "cold-turkey-blocker" ];
+  casks = [ "cold-turkey-blocker" ];
 }

--- a/modules/productivity/figma.nix
+++ b/modules/productivity/figma.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "figma";
-  system.homebrew.casks = [ "figma" ];
+  casks = [ "figma" ];
 }

--- a/modules/productivity/granola.nix
+++ b/modules/productivity/granola.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "granola";
-  system.homebrew.casks = [ "granola" ];
+  casks = [ "granola" ];
 }

--- a/modules/productivity/libreoffice.nix
+++ b/modules/productivity/libreoffice.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "libreoffice";
-  system.homebrew.casks = [ "libreoffice" ];
+  casks = [ "libreoffice" ];
 }

--- a/modules/productivity/loom.nix
+++ b/modules/productivity/loom.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "loom";
-  system.homebrew.casks = [ "loom" ];
+  casks = [ "loom" ];
 }

--- a/modules/productivity/netnewswire.nix
+++ b/modules/productivity/netnewswire.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "netnewswire";
-  system.homebrew.casks = [ "netnewswire" ];
+  casks = [ "netnewswire" ];
 }

--- a/modules/productivity/notion-calendar.nix
+++ b/modules/productivity/notion-calendar.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "notion-calendar";
-  system.homebrew.casks = [ "notion-calendar" ];
+  casks = [ "notion-calendar" ];
 }

--- a/modules/productivity/obsidian.nix
+++ b/modules/productivity/obsidian.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "obsidian";
-  system.homebrew.casks = [ "obsidian" ];
+  casks = [ "obsidian" ];
 }

--- a/modules/productivity/openclaw.nix
+++ b/modules/productivity/openclaw.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "openclaw";
-  system.homebrew.casks = [ "openclaw" ];
+  casks = [ "openclaw" ];
 }

--- a/modules/productivity/selfcontrol.nix
+++ b/modules/productivity/selfcontrol.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "selfcontrol";
-  system.homebrew.casks = [ "selfcontrol" ];
+  casks = [ "selfcontrol" ];
 }

--- a/modules/productivity/sparkmail.nix
+++ b/modules/productivity/sparkmail.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "sparkmail";
-  system.homebrew.casks = [ "readdle-spark" ];
+  casks = [ "readdle-spark" ];
 }

--- a/modules/productivity/windows-app.nix
+++ b/modules/productivity/windows-app.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "windows-app";
-  system.homebrew.casks = [ "windows-app" ];
+  casks = [ "windows-app" ];
 }

--- a/modules/productivity/word.nix
+++ b/modules/productivity/word.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "word";
-  system.homebrew.casks = [ "microsoft-word" ];
+  casks = [ "microsoft-word" ];
 }

--- a/modules/productivity/zotero.nix
+++ b/modules/productivity/zotero.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "zotero";
-  system.homebrew.casks = [ "zotero" ];
+  casks = [ "zotero" ];
 }

--- a/modules/security/1password.nix
+++ b/modules/security/1password.nix
@@ -6,7 +6,7 @@
 mkUserModule {
   name = "1password";
   requires = [ "git" ];
-  system.homebrew.casks = [
+  casks = [
     "1password"
     "1password-cli"
   ];

--- a/modules/security/yubikey.nix
+++ b/modules/security/yubikey.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "yubikey";
-  system.homebrew.casks = [ "yubico-authenticator" ];
+  casks = [ "yubico-authenticator" ];
 }

--- a/modules/terminal/warp.nix
+++ b/modules/terminal/warp.nix
@@ -1,5 +1,5 @@
 { mkUserModule, ... }:
 mkUserModule {
   name = "warp";
-  system.homebrew.casks = [ "warp" ];
+  casks = [ "warp" ];
 }


### PR DESCRIPTION
The casks field expands to homebrew.casks on darwin only and is structurally absent on linux, preparing for NixOS host support. Brews in chrome-cli and rtk are explicitly wrapped in forPlatform to ensure cross-platform compatibility.