### PR TITLE
fix(darwin): guard launchd agents behind forPlatform

### DIFF
--- a/modules/dev/hermes/gateway.nix
+++ b/modules/dev/hermes/gateway.nix
@@ -17,46 +17,51 @@
 # atomically rewritten by nix-darwin's setupLaunchAgents step.
 {
   hermes,
+  forPlatform,
   ...
 }:
 {
-  system =
-    { partUsers }:
-    let
-      # mkUserModule passes partUsers as { username = userCfg; ... }.
-      # The gateway is inherently host-scoped (one HERMES_HOME per machine),
-      # so only one user may enable it.  Loud fail beats a silent last-wins.
-      usernames = builtins.attrNames partUsers;
-      username =
-        if builtins.length usernames == 1 then
-          builtins.head usernames
-        else
-          throw "hermes.gateway: exactly one user must enable the gateway (got: ${builtins.toJSON usernames})";
-      nalumDir = "/Users/${username}/nalum";
-    in
-    {
-      launchd.user.agents.hermes-gateway = {
-        serviceConfig = {
-          Label = "ai.hermes.gateway";
-          ProgramArguments = [
-            "${hermes}/bin/hermes"
-            "gateway"
-            "run"
-            "--replace"
-          ];
-          EnvironmentVariables = {
-            HERMES_HOME = nalumDir;
+  # launchd is darwin-only; systemd port deferred until wanted on linux.
+  system = forPlatform {
+    linux = _: { };
+    darwin =
+      { partUsers }:
+      let
+        # mkUserModule passes partUsers as { username = userCfg; ... }.
+        # The gateway is inherently host-scoped (one HERMES_HOME per machine),
+        # so only one user may enable it.  Loud fail beats a silent last-wins.
+        usernames = builtins.attrNames partUsers;
+        username =
+          if builtins.length usernames == 1 then
+            builtins.head usernames
+          else
+            throw "hermes.gateway: exactly one user must enable the gateway (got: ${builtins.toJSON usernames})";
+        nalumDir = "/Users/${username}/nalum";
+      in
+      {
+        launchd.user.agents.hermes-gateway = {
+          serviceConfig = {
+            Label = "ai.hermes.gateway";
+            ProgramArguments = [
+              "${hermes}/bin/hermes"
+              "gateway"
+              "run"
+              "--replace"
+            ];
+            EnvironmentVariables = {
+              HERMES_HOME = nalumDir;
+            };
+            WorkingDirectory = nalumDir;
+            RunAtLoad = true;
+            # Restart only on abnormal exit — clean shutdowns (e.g. `hermes
+            # gateway stop`) should stay stopped.
+            KeepAlive = {
+              SuccessfulExit = false;
+            };
+            StandardOutPath = "${nalumDir}/logs/gateway.log";
+            StandardErrorPath = "${nalumDir}/logs/gateway.error.log";
           };
-          WorkingDirectory = nalumDir;
-          RunAtLoad = true;
-          # Restart only on abnormal exit — clean shutdowns (e.g. `hermes
-          # gateway stop`) should stay stopped.
-          KeepAlive = {
-            SuccessfulExit = false;
-          };
-          StandardOutPath = "${nalumDir}/logs/gateway.log";
-          StandardErrorPath = "${nalumDir}/logs/gateway.error.log";
         };
       };
-    };
+  };
 }

--- a/modules/dev/hermes/hermes.nix
+++ b/modules/dev/hermes/hermes.nix
@@ -73,6 +73,7 @@
   mkUserModule,
   pkgs,
   inputs,
+  forPlatform,
   ...
 }:
 let
@@ -116,7 +117,7 @@ mkUserModule {
   name = "hermes";
 
   parts = {
-    gateway = import ./gateway.nix { inherit hermes; };
+    gateway = import ./gateway.nix { inherit hermes forPlatform; };
   };
 
   home =

--- a/modules/dev/opencode/opencode.nix
+++ b/modules/dev/opencode/opencode.nix
@@ -4,6 +4,7 @@
   lib,
   inputs,
   system,
+  forPlatform,
   ...
 }:
 let
@@ -27,6 +28,7 @@ mkUserModule {
       inherit
         pkgs
         lib
+        forPlatform
         opencode-unwrapped
         serverPort
         ;

--- a/modules/dev/opencode/server.nix
+++ b/modules/dev/opencode/server.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   lib,
+  forPlatform,
   opencode-unwrapped,
   serverPort,
 }:
@@ -243,20 +244,24 @@ in
     };
   };
 
-  system =
-    { partUsers }:
-    lib.mkIf (lib.any (u: u.opencode.server.autoAttach) (lib.attrValues partUsers)) {
-      launchd.user.agents.opencode-server = {
-        serviceConfig = {
-          Label = "com.opencode.server";
-          ProgramArguments = [ "${serverLauncher}" ];
-          RunAtLoad = true;
-          KeepAlive = true;
-          StandardOutPath = "/tmp/opencode-server.log";
-          StandardErrorPath = "/tmp/opencode-server.log";
+  # launchd is darwin-only; systemd port deferred until wanted on linux.
+  system = forPlatform {
+    linux = _: { };
+    darwin =
+      { partUsers }:
+      lib.mkIf (lib.any (u: u.opencode.server.autoAttach) (lib.attrValues partUsers)) {
+        launchd.user.agents.opencode-server = {
+          serviceConfig = {
+            Label = "com.opencode.server";
+            ProgramArguments = [ "${serverLauncher}" ];
+            RunAtLoad = true;
+            KeepAlive = true;
+            StandardOutPath = "/tmp/opencode-server.log";
+            StandardErrorPath = "/tmp/opencode-server.log";
+          };
         };
       };
-    };
+  };
 
   home =
     { cfg, ... }:

--- a/modules/ledger/ledger.nix
+++ b/modules/ledger/ledger.nix
@@ -1,8 +1,14 @@
-{ mkUserModule, pkgs, ... }:
+{
+  mkUserModule,
+  pkgs,
+  forPlatform,
+  ...
+}:
 mkUserModule {
   name = "ledger";
-  system = {
-    launchd.user.agents.ledger-sync = {
+  # launchd is darwin-only; systemd timer port deferred until wanted on linux.
+  system = forPlatform {
+    darwin.launchd.user.agents.ledger-sync = {
       command = ./ledger-sync.sh;
 
       serviceConfig = {


### PR DESCRIPTION
launchd is darwin-only; the guards make these modules structurally
absent on linux so the NixOS host can evaluate (systemd ports deferred
until wanted).
