### PR TITLE
refactor(linux): migrate linux modules to mkUserModule

### DIFF
--- a/modules/linux/dconf.nix
+++ b/modules/linux/dconf.nix
@@ -1,4 +1,7 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [ dconf ];
+{ mkUserModule, pkgs, ... }:
+mkUserModule {
+  name = "dconf";
+  home = {
+    home.packages = with pkgs; [ dconf ];
+  };
 }

--- a/modules/linux/feh.nix
+++ b/modules/linux/feh.nix
@@ -1,4 +1,7 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [ feh ];
+{ mkUserModule, pkgs, ... }:
+mkUserModule {
+  name = "feh";
+  home = {
+    home.packages = with pkgs; [ feh ];
+  };
 }

--- a/modules/linux/flameshot.nix
+++ b/modules/linux/flameshot.nix
@@ -1,5 +1,7 @@
-_: {
-  services.flameshot = {
-    enable = true;
+{ mkUserModule, ... }:
+mkUserModule {
+  name = "flameshot";
+  home = {
+    services.flameshot.enable = true;
   };
 }

--- a/modules/linux/gtk.nix
+++ b/modules/linux/gtk.nix
@@ -1,10 +1,13 @@
-{ pkgs, ... }:
-{
-  gtk = {
-    enable = true;
-    theme = {
-      name = "Materia-dark";
-      package = pkgs.materia-theme;
+{ mkUserModule, pkgs, ... }:
+mkUserModule {
+  name = "gtk";
+  home = {
+    gtk = {
+      enable = true;
+      theme = {
+        name = "Materia-dark";
+        package = pkgs.materia-theme;
+      };
     };
   };
 }


### PR DESCRIPTION
The stubs predated mkUserModule and were raw home-manager attrsets,
which break when imported as system modules by NixOS host discovery.
Now proper capability modules with per-user enable flags.
