### PR TITLE
feat(lib): add mkNixOSHost factory and polaris host

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -60,6 +60,26 @@
         "type": "github"
       }
     },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -284,6 +304,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-nixos": {
+      "locked": {
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "npm-lockfile-fix": {
       "inputs": {
         "nixpkgs": [
@@ -419,6 +455,7 @@
         "brew-src": "brew-src",
         "darwin": "darwin",
         "direnv-instant": "direnv-instant",
+        "disko": "disko",
         "hermes-agent": "hermes-agent",
         "hermes-claude-auth": "hermes-claude-auth",
         "home-manager": "home-manager",
@@ -429,6 +466,7 @@
         "nix-homebrew": "nix-homebrew",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-nixos": "nixpkgs-nixos",
         "opencode": "opencode",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,15 @@
       url = "github:nixos/nixpkgs/nixpkgs-unstable";
     };
 
+    # NixOS hosts track nixos-unstable instead: it's gated on NixOS
+    # integration tests and fully Hydra-cached for NixOS closures, which
+    # nixpkgs-unstable (the darwin-friendly branch above) is not. Inputs are
+    # fetched lazily per evaluated output, so each machine only ever
+    # downloads its own branch.
+    nixpkgs-nixos = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+
     utils = {
       url = "github:numtide/flake-utils";
     };
@@ -59,6 +68,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Declarative disk partitioning for the NixOS host (polaris). The disko
+    # config lives in the host module; the device is chosen at install time
+    # via `disko-install --disk`.
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # VS Code Marketplace + Open VSX extensions as Nix packages. nixpkgs only
     # ships a few hundred extensions; this exposes the full marketplace so the
     # vscode module can declare extensions like oxc, supermaven, etc.
@@ -91,10 +108,15 @@
     { nixpkgs, utils, ... }@inputs:
     let
       mkDarwinHost = import ./lib/mkDarwinHost.nix { inherit inputs; };
+      mkNixOSHost = import ./lib/mkNixOSHost.nix { inherit inputs; };
     in
     {
       darwinConfigurations = {
         m1 = import ./modules/hosts/m1.nix { inherit mkDarwinHost; };
+      };
+
+      nixosConfigurations = {
+        polaris = import ./modules/hosts/polaris.nix { inherit mkNixOSHost; };
       };
     }
     // utils.lib.eachDefaultSystem (

--- a/lib/mkNixOSHost.nix
+++ b/lib/mkNixOSHost.nix
@@ -1,0 +1,110 @@
+# mkNixOSHost — creates a NixOS system from a structured declaration.
+#
+# Mirror of mkDarwinHost with the same platform-agnostic interface, so host
+# files stay declarative regardless of platform. Differences from darwin:
+#   - nixpkgs.lib.nixosSystem instead of darwin.lib.darwinSystem
+#   - home-manager.nixosModules instead of darwinModules
+#   - no nix-homebrew (Homebrew is a darwin concept)
+#   - module discovery excludes modules/darwin/ instead of modules/linux/
+#
+# Signature: { inputs } -> { hostName, primaryUser, ... } -> nixosSystem
+#
+# Fields (identical shape to mkDarwinHost):
+#
+#   hostName:     (required) Network hostname. Sets networking.hostName.
+#
+#   primaryUser:  (required) The primary user of this host. Accepts a user
+#                 function (imported mkUser file) or a plain string.
+#                 Currently informational on NixOS (darwin needs it for
+#                 system.primaryUser; kept for interface parity).
+#
+#   system:       (optional, default "x86_64-linux") Nix system identifier.
+#
+#   stateVersion: (optional, default "26.05") NixOS state version (string,
+#                 unlike nix-darwin's integer).
+#
+#   users:        (optional, default []) List of user functions (imported
+#                 mkUser files).
+#
+#   extraModules: (optional, default []) Escape hatch for additional modules
+#                 (hardware config, disko layout, ...).
+#
+# Usage:
+#
+#   # modules/hosts/polaris.nix
+#   { mkNixOSHost }:
+#   let
+#     fernando = import ../users/polaris-fernando.nix;
+#   in
+#   mkNixOSHost {
+#     hostName = "polaris";
+#     primaryUser = fernando;
+#     users = [ fernando ];
+#   }
+#
+{ inputs }:
+let
+  inherit (inputs) home-manager;
+  # NixOS hosts evaluate against nixos-unstable (see flake.nix inputs).
+  nixpkgs = inputs.nixpkgs-nixos;
+
+  mkUser = import ./mkUser.nix;
+
+  discoverModules = import ./discoverModules.nix { inherit (nixpkgs) lib; };
+
+  globalModules = discoverModules {
+    modulesDir = ../modules;
+    exclude = [
+      "hosts"
+      "users"
+      "darwin"
+    ];
+  };
+
+  # Wrap a user function so the module system receives the inner module.
+  userToModule = userFn: args: (userFn args).module;
+in
+{
+  hostName,
+  # Unused on NixOS for now (darwin needs system.primaryUser); accepted for
+  # interface parity with mkDarwinHost.
+  primaryUser,
+  system ? "x86_64-linux",
+  stateVersion ? "26.05",
+  users ? [ ],
+  extraModules ? [ ],
+}:
+nixpkgs.lib.nixosSystem {
+  inherit system;
+
+  specialArgs = {
+    inherit inputs system;
+    mkUserModule = import ./mkUserModule.nix;
+    mkSystemModule = import ./mkSystemModule.nix;
+    inherit mkUser;
+    forPlatform = import ./forPlatform.nix system;
+  };
+
+  modules = [
+    home-manager.nixosModules.home-manager
+
+    {
+      networking.hostName = hostName;
+      system.stateVersion = stateVersion;
+
+      nixpkgs = {
+        config.allowUnfree = true;
+        # Same overlay as mkDarwinHost — vscode module references
+        # pkgs.vscode-marketplace on every platform.
+        overlays = [ inputs.nix-vscode-extensions.overlays.default ];
+      };
+
+      home-manager = {
+        useGlobalPkgs = true;
+      };
+    }
+  ]
+  ++ map userToModule users
+  ++ extraModules
+  ++ globalModules;
+}

--- a/lib/mkUser.nix
+++ b/lib/mkUser.nix
@@ -67,9 +67,22 @@ in
         {
           modules.users.${name} = moduleEnables;
 
-          users.users.${name}.home = forPlatform {
-            darwin = "/Users/${name}";
-            linux = "/home/${name}";
+          users.users.${name} = {
+            home = forPlatform {
+              darwin = "/Users/${name}";
+              linux = "/home/${name}";
+            };
+          }
+          # NixOS requires an explicit account class (darwin does not) and
+          # won't create the account without it.
+          // forPlatform {
+            linux = {
+              isNormalUser = true;
+              extraGroups = [
+                "wheel"
+                "networkmanager"
+              ];
+            };
           };
 
           home-manager.users.${name} = {

--- a/modules/hosts/polaris.nix
+++ b/modules/hosts/polaris.nix
@@ -1,0 +1,23 @@
+{ mkNixOSHost }:
+let
+  fernando = import ../users/polaris-fernando.nix;
+in
+mkNixOSHost {
+  hostName = "polaris";
+  primaryUser = fernando;
+  users = [ fernando ];
+
+  extraModules = [
+    # Placeholder hardware/disk config so the toplevel evaluates before the
+    # machine exists. Replaced in Phase 1 (disko layout) and at install time
+    # (nixos-generate-config → polaris-hardware.nix).
+    {
+      fileSystems."/" = {
+        device = "/dev/disk/by-label/nixos";
+        fsType = "btrfs";
+      };
+      boot.loader.systemd-boot.enable = true;
+      boot.loader.efi.canTouchEfiVariables = true;
+    }
+  ];
+}

--- a/modules/users/polaris-fernando.nix
+++ b/modules/users/polaris-fernando.nix
@@ -1,0 +1,6 @@
+# polaris user composition — first wave is CLI-only (plan Phase 1 grows this).
+{ mkUser, ... }:
+mkUser {
+  name = "fernando";
+  bat.enable = true;
+}


### PR DESCRIPTION
mkNixOSHost mirrors mkDarwinHost with the same platform-agnostic
interface: nixosSystem instead of darwinSystem, home-manager nixos
module, no nix-homebrew, and module discovery excluding modules/darwin.

New inputs: nixpkgs-nixos (nixos-unstable — NixOS-test-gated and fully
Hydra-cached, while darwin stays on nixpkgs-unstable; lazy input
fetching keeps each platform's inputs off the other machine) and disko
(device chosen at install time via disko-install --disk).

mkUser gains the linux account bootstrap (isNormalUser, wheel and
networkmanager groups) that NixOS requires and darwin does not.

polaris is a minimal eval target with placeholder filesystem config,
replaced by the real disko layout and generated hardware config in
later phases.
