### PR TITLE
feat(polaris): add disko disk layout with LUKS and btrfs

### DIFF
--- a/modules/hosts/polaris-disk.nix
+++ b/modules/hosts/polaris-disk.nix
@@ -1,0 +1,73 @@
+# polaris disk layout — disko-managed, LUKS full-disk encryption → btrfs.
+#
+# The device is a placeholder: install day overrides it with
+#   disko-install --disk main /dev/disk/by-id/<real-disk>
+# so this file never needs editing for hardware changes.
+#
+# No swap partition by design: zram covers daily memory pressure, and
+# future hibernation uses a resizable btrfs swapfile (see plan) — sized
+# to whatever RAM the machine has at that point.
+#
+# Subvolume layout keeps snapshots cheap to add later (snapper/btrbk
+# operate per-subvolume) without configuring any snapshot tooling now.
+{ inputs, ... }:
+{
+  imports = [ inputs.disko.nixosModules.disko ];
+
+  disko.devices.disk.main = {
+    type = "disk";
+    device = "/dev/disk/by-id/PLACEHOLDER";
+    content = {
+      type = "gpt";
+      partitions = {
+        ESP = {
+          type = "EF00";
+          size = "1G";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        luks = {
+          size = "100%";
+          content = {
+            type = "luks";
+            name = "cryptroot";
+            settings.allowDiscards = true;
+            content = {
+              type = "btrfs";
+              extraArgs = [ "-f" ];
+              subvolumes = {
+                "@" = {
+                  mountpoint = "/";
+                  mountOptions = [
+                    "compress=zstd"
+                    "noatime"
+                  ];
+                };
+                "@home" = {
+                  mountpoint = "/home";
+                  mountOptions = [
+                    "compress=zstd"
+                    "noatime"
+                  ];
+                };
+                "@nix" = {
+                  mountpoint = "/nix";
+                  mountOptions = [
+                    "compress=zstd"
+                    "noatime"
+                  ];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  zramSwap.enable = true;
+}

--- a/modules/hosts/polaris.nix
+++ b/modules/hosts/polaris.nix
@@ -8,14 +8,11 @@ mkNixOSHost {
   users = [ fernando ];
 
   extraModules = [
-    # Placeholder hardware/disk config so the toplevel evaluates before the
-    # machine exists. Replaced in Phase 1 (disko layout) and at install time
-    # (nixos-generate-config → polaris-hardware.nix).
+    ./polaris-disk.nix
+
+    # Boot loader; hardware config generated at install time will join this
+    # list as polaris-hardware.nix (nixos-generate-config --show-hardware-config).
     {
-      fileSystems."/" = {
-        device = "/dev/disk/by-label/nixos";
-        fsType = "btrfs";
-      };
       boot.loader.systemd-boot.enable = true;
       boot.loader.efi.canTouchEfiVariables = true;
     }


### PR DESCRIPTION
LUKS full-disk encryption over btrfs subvolumes (@, @home, @nix) with
zstd compression, 1GB ESP, zram for swap. No swap partition by design —
future hibernation uses a resizable btrfs swapfile instead, so RAM
upgrades never force repartitioning.

Device is a placeholder overridden at install time via
disko-install --disk main /dev/disk/by-id/<disk>.
