### PR TITLE
feat(linux): add boot and network base modules

### DIFF
--- a/modules/hosts/polaris.nix
+++ b/modules/hosts/polaris.nix
@@ -10,11 +10,12 @@ mkNixOSHost {
   extraModules = [
     ./polaris-disk.nix
 
-    # Boot loader; hardware config generated at install time will join this
-    # list as polaris-hardware.nix (nixos-generate-config --show-hardware-config).
+    # Host specifics; hardware config generated at install time will join
+    # this list as polaris-hardware.nix (nixos-generate-config).
     {
-      boot.loader.systemd-boot.enable = true;
-      boot.loader.efi.canTouchEfiVariables = true;
+      # Windows (separate disk) keeps the RTC in localtime; adjusting here
+      # avoids registry surgery on the Windows side.
+      time.hardwareClockInLocalTime = true;
     }
   ];
 }

--- a/modules/linux/boot.nix
+++ b/modules/linux/boot.nix
@@ -1,0 +1,21 @@
+# systemd-boot for NixOS hosts — no GRUB.
+#
+# The edk2 UEFI shell entry exists to discover the Windows ESP device
+# handle for dual-boot chainloading (Windows lives on a separate disk, so
+# systemd-boot cannot auto-detect it). The windows entry itself is added
+# per-host once the handle is known (see .omo/plans/nixos-second-host.md).
+{ mkSystemModule, ... }:
+mkSystemModule {
+  name = "boot";
+  config.boot.loader = {
+    systemd-boot = {
+      enable = true;
+      consoleMode = "max";
+      editor = false;
+      configurationLimit = 20;
+      edk2-uefi-shell.enable = true;
+    };
+    efi.canTouchEfiVariables = true;
+    timeout = 5;
+  };
+}

--- a/modules/linux/network.nix
+++ b/modules/linux/network.nix
@@ -1,0 +1,10 @@
+# NetworkManager + redistributable firmware (WiFi/BT chips need it —
+# polaris: Realtek RTL8922AE).
+{ mkSystemModule, ... }:
+mkSystemModule {
+  name = "network";
+  config = {
+    networking.networkmanager.enable = true;
+    hardware.enableRedistributableFirmware = true;
+  };
+}


### PR DESCRIPTION
systemd-boot (consoleMode max, no editor, edk2 shell for the Windows
dual-boot handle discovery), NetworkManager, redistributable firmware.
polaris keeps RTC in localtime to coexist with Windows.
