### PR TITLE
feat(linux): add pipewire and bluetooth modules

### DIFF
--- a/modules/linux/bluetooth.nix
+++ b/modules/linux/bluetooth.nix
@@ -1,0 +1,14 @@
+# Bluetooth + blueman applet (WM-only desktop, no DE bluetooth UI).
+# Note: polaris' RTL8922AE has rough BT/WiFi coexistence — if WiFi drops,
+# test with BT off before blaming the driver.
+{ mkSystemModule, ... }:
+mkSystemModule {
+  name = "bluetooth";
+  config = {
+    hardware.bluetooth = {
+      enable = true;
+      powerOnBoot = true;
+    };
+    services.blueman.enable = true;
+  };
+}

--- a/modules/linux/pipewire.nix
+++ b/modules/linux/pipewire.nix
@@ -1,0 +1,12 @@
+# PipeWire audio with PulseAudio compat — also the screenshare transport
+# for Wayland portals.
+{ mkSystemModule, ... }:
+mkSystemModule {
+  name = "pipewire";
+  config.services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+  };
+}


### PR DESCRIPTION
PipeWire with PulseAudio compat (also the Wayland screenshare
transport); bluetooth with blueman for the WM-only desktop.
