### PR TITLE
fix(nvim): stop minuet crashing on missing API key, guard other runtime deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ A nix-darwin flake configuration for a single macOS Apple Silicon host (`vega`),
 - **Rebuild:** `sudo darwin-rebuild switch --flake .#vega`
 - **Format:** `nixfmt <file.nix>` (RFC style, enforced by pre-commit)
 - **Lint:** `statix check .` — **run after every edit to .nix files, before rebuild**
+- **Check:** `nix flake check` — **run after every edit to embedded Lua, before rebuild.** Byte-compiles the generated nvim `init.lua`. Nix treats embedded Lua as opaque text, so `statix`/`nixfmt` cannot see a Lua syntax error and a rebuild will happily install a broken nvim config.
 - **Shell lint:** `shellcheck <file.sh>`
 - **Enter dev shell:** `nix develop` (auto-activates via direnv)
 

--- a/flake.nix
+++ b/flake.nix
@@ -117,8 +117,9 @@
     let
       mkDarwinHost = import ./lib/mkDarwinHost.nix { inherit inputs; };
       mkNixOSHost = import ./lib/mkNixOSHost.nix { inherit inputs; };
-    in
-    {
+
+      inherit (nixpkgs) lib;
+
       darwinConfigurations = {
         vega = import ./modules/hosts/vega.nix { inherit mkDarwinHost; };
       };
@@ -126,14 +127,46 @@
       nixosConfigurations = {
         polaris = import ./modules/hosts/polaris.nix { inherit mkNixOSHost; };
       };
+    in
+    {
+      inherit darwinConfigurations nixosConfigurations;
     }
     // utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+
+        # The neovim config is Lua embedded in Nix strings, which Nix treats as
+        # opaque text — a syntax error there survives a rebuild and only shows
+        # up when nvim next starts. Byte-compile the generated init.lua so
+        # `nix flake check` catches it first. LuaJIT, not lua5_1, because that
+        # is what nvim actually runs (it accepts `goto`, 5.1 does not).
+        #
+        # ponytail: syntax only. A missing API key or absent binary still needs
+        # a guard in the module itself — this check cannot see runtime paths.
+        nvimInitCheck =
+          hostName: hostCfg:
+          pkgs.runCommand "nvim-init-lua-${hostName}" { } ''
+            ${pkgs.luajit}/bin/luajit -b ${
+              hostCfg.config.home-manager.users.fernando.xdg.configFile."nvim/init.lua".source
+            } /dev/null && touch $out
+          '';
       in
       {
-        packages = pkgs;
+        # legacyPackages, not packages: this is the whole nixpkgs set, and
+        # `nix flake check` requires every `packages.<system>.<name>` to be a
+        # derivation (`pkgs.system` is a string, so it failed the check).
+        # legacyPackages is the output nixpkgs itself uses for exactly this,
+        # and `nix build .#<anypkg>` still resolves through it.
+        legacyPackages = pkgs;
+
+        checks =
+          lib.optionalAttrs (system == "aarch64-darwin") {
+            nvim-init-vega = nvimInitCheck "vega" darwinConfigurations.vega;
+          }
+          // lib.optionalAttrs (system == "x86_64-linux") {
+            nvim-init-polaris = nvimInitCheck "polaris" nixosConfigurations.polaris;
+          };
 
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/modules/editor/nvim/ai.nix
+++ b/modules/editor/nvim/ai.nix
@@ -12,11 +12,18 @@
       plugins = with pkgs; [
         # ── AI autocomplete (minuet-ai, Codestral FIM) ─────
         # Requires CODESTRAL_API_KEY in the environment (free tier at
-        # https://console.mistral.ai/codestral). Without it, completions
-        # are simply silent.
+        # https://console.mistral.ai/codestral).
+        #
+        # The guard below is load-bearing: minuet does NOT validate the key.
+        # codestral.lua calls straight into openai_base.lua, which does
+        # `'Bearer ' .. utils.get_api_key(...)`. With no key that is a
+        # concat-on-nil, thrown from a vim.schedule callback on every
+        # completion trigger — i.e. constantly, while typing.
+        # Skipping setup() entirely means no autocmds, so nothing can fire.
         {
           plugin = vimPlugins.minuet-ai-nvim;
           config = ''
+            if vim.env.CODESTRAL_API_KEY and vim.env.CODESTRAL_API_KEY ~= "" then
             require('minuet').setup({
               provider = 'codestral',
               provider_options = {
@@ -42,6 +49,7 @@
                 },
               },
             })
+            end
           '';
         }
 

--- a/modules/editor/nvim/explorer.nix
+++ b/modules/editor/nvim/explorer.nix
@@ -61,7 +61,8 @@
               callback = function()
                 -- Only open if we're not opening a specific file via stdin or with args that are directories
                 if vim.fn.argc() == 0 then return end
-                vim.cmd('Neotree show right')
+                -- ponytail: pcall so a broken/missing Neotree can't abort startup
+                pcall(vim.cmd, 'Neotree show right')
               end,
             })
 
@@ -70,7 +71,7 @@
               once = true,
               callback = function()
                 vim.schedule(function()
-                  vim.cmd('Neotree show right')
+                  pcall(vim.cmd, 'Neotree show right')
                 end)
               end,
             })

--- a/modules/editor/nvim/git.nix
+++ b/modules/editor/nvim/git.nix
@@ -17,6 +17,12 @@
                 vim.fn.system("git rev-parse --verify origin/main 2>/dev/null")
                 base = vim.v.shell_error == 0 and "origin/main" or "origin/master"
               end
+              -- ponytail: one verify on the final ref covers every fallback path
+              vim.fn.system("git rev-parse --verify " .. base .. " 2>/dev/null")
+              if vim.v.shell_error ~= 0 then
+                vim.notify("No base branch (tried origin/HEAD, origin/main, origin/master)", vim.log.levels.WARN)
+                return
+              end
               vim.cmd("DiffviewOpen " .. base .. "...HEAD")
             end, desc = "Review branch vs base" },
           { "<leader>Gf", "<cmd>DiffviewFileHistory %<cr>", desc = "File history" },

--- a/modules/editor/nvim/lsp.nix
+++ b/modules/editor/nvim/lsp.nix
@@ -121,7 +121,12 @@ in
         vim.lsp.config('rust_analyzer', {
           settings = {
             ['rust-analyzer'] = {
-              checkOnSave = { command = 'clippy' },
+              -- ponytail: check-on-save shells out to cargo; without a toolchain
+              -- rust-analyzer errors on every save. Gate it on clippy existing.
+              -- (`checkOnSave` is a bool in current rust-analyzer; the command
+              -- moved to `check.command`.)
+              checkOnSave = vim.fn.executable('cargo-clippy') == 1,
+              check = { command = 'clippy' },
               cargo = { allFeatures = true },
             },
           },


### PR DESCRIPTION
Typing in nvim raised this continuously:

```
vim.schedule callback: minuet/backends/openai_base.lua:137: attempt to concatenate a nil value
```

## Cause

minuet does no key validation. `codestral.lua` passes options straight to `openai_base.lua`, which builds the auth header as `'Bearer ' .. utils.get_api_key(...)`. `get_api_key` returns `nil` for a missing env var, so the concat throws — from a `vim.schedule` callback, on every completion trigger.

`CODESTRAL_API_KEY` is not set anywhere in this config, so the plugin has been raising this rather than being "simply silent" as the old comment claimed.

Guarding `setup()` instead of the call site is what makes it airtight: minuet registers its 8 `MinuetVirtualText` autocmds from inside `setup()`, and `trigger()` is only reachable through those or through keymaps `setup()` installs. Skipping it leaves **0** autocmds, so no path into the crash exists.

## Verification

The bug needs genuine insert mode — `trigger()` returns early unless `mode() == 'i'`, and under `--headless` neither `startinsert` nor `feedkeys` nor `nvim_input` holds insert across the event loop. Simpler probes reported a **false pass on the broken config**, so this was verified by driving a real nvim over a socket:

| Config | mode during trigger | Result |
|---|---|---|
| before | `'i'` | `openai_base.lua:137: attempt to concatenate a nil value` |
| after | `'i'` | clean |

Both runs confirmed `mode = 'i'`, so `trigger()` genuinely ran in each — otherwise the comparison would be two silent no-ops.

## Same class of bug, found by auditing

- **rust-analyzer** ran check-on-save with clippy unconditionally, but no rust toolchain is provisioned for this user (neither `cargo` nor `clippy` on PATH), so every Rust save errored. Now gated on `cargo-clippy` existing. The command also moves to `check.command` — `checkOnSave = { command = ... }` is the old schema and current rust-analyzer (2026-04-06 here) expects a bool, so the clippy setting was being ignored regardless.
- **`<leader>GD`** fell back to `origin/master` without checking it resolves, running `DiffviewOpen` on an invalid ref. Now verified once on the resolved ref. Checked against three repos: no origin warns and opens nothing; `origin/main` and this repo resolve as before.
- **Neotree** opens are now `pcall`'d; one runs inside `vim.schedule`, where a failure surfaces as the same detached error the minuet bug produced.

## Validation

Lua embedded in Nix strings is opaque text to Nix — `nixfmt` and `statix` cannot see inside it, so a syntax error survives a rebuild and only appears when nvim next starts. `nix flake check` now byte-compiles the generated `init.lua`, letting Nix do the extraction so no string parsing is needed. LuaJIT rather than lua5_1 because that is what nvim runs (5.1 rejects `goto`). Confirmed it fails on a deliberately unbalanced `if`, pointing at the exact location:

```
luajit: 'end' expected (to close 'if' at line 714)
```

**This catches syntax only.** It would not have caught the minuet crash — headless boot was already clean there. That is why the runtime paths got explicit guards rather than relying on it.

`packages` also becomes `legacyPackages`: `nix flake check` requires every `packages.<system>.<name>` to be a derivation, and this exposes the whole nixpkgs set where `pkgs.system` is a string, so the check aborted before running anything and **had been failing on main**. `nix build .#<pkg>` still resolves through `legacyPackages`.

## Notes

- Not yet rebuilt — `darwin-rebuild` needs an interactive sudo password. Everything above was verified against the exact `init.lua` the rebuild will install.
- Separately: `rust-analyzer` is installed with no `cargo` behind it and no `rust.enable` in the user config. Worth either dropping it or wiring up a real toolchain.
