### PR TITLE
fix(tmux): clamp cpu widget reading at 100%

### DIFF
--- a/modules/cli/tmux/statusbar.nix
+++ b/modules/cli/tmux/statusbar.nix
@@ -18,9 +18,10 @@ let
       # no cheap instantaneous CPU%: top -l 1 costs ~1.2s and iostat -c 2 ~1.0s,
       # both far too slow for a 5s status interval. vm.loadavg is ~18ms.
       # ponytail: load counts runnable + uninterruptible tasks, so this reads a
-      # little higher than top's user+sys and can exceed 100%.
+      # little higher than top's user+sys. Clamped to 100 — past saturation the
+      # backlog depth doesn't change what the widget is telling you.
       ncpu=$(sysctl -n hw.ncpu 2>/dev/null)
-      cpu=$(sysctl -n vm.loadavg 2>/dev/null | awk -v n="''${ncpu:-1}" '{ printf "%.0f", $2 / n * 100 }')
+      cpu=$(sysctl -n vm.loadavg 2>/dev/null | awk -v n="''${ncpu:-1}" '{ v = $2 / n * 100; printf "%.0f", (v > 100 ? 100 : v) }')
       [[ -z "''${cpu}" ]] && exit 0
 
       if (( cpu < 30 )); then


### PR DESCRIPTION
## What

The status bar CPU widget derives its percentage from the 1-minute load average divided by core count. Load average counts *queued* tasks, not just running ones, so on a busy machine the widget reported values like `300%` or `520%` — which reads as a broken widget rather than as "you are saturated".

Clamps the value at 100.

## Why not compute real CPU%

macOS exposes no cheap instantaneous CPU%. `top -l 1` costs ~1.2s and `iostat -c 2` ~1.0s, both far too slow for a 5s status interval. `vm.loadavg` is ~18ms. The existing comment already documents this tradeoff; this change just stops the tradeoff from leaking a nonsense number into the status bar.

Past full saturation the backlog depth doesn't change what the widget is telling you, and the red threshold (>= 85%) already covers it.

## Verification

Built widget driven through a `sysctl` shim with synthetic load values, `hw.ncpu = 14`:

| load avg | before | after |
|---|---|---|
| 0.14 | 1% | 1% |
| 7.0 | 50% | 50% |
| 14.0 | 100% | 100% |
| 28.0 | 200% | 100% |
| 73.2 | 523% | 100% |

- `nix build .#darwinConfigurations.vega.system` passes (shellcheck runs as part of `writeShellApplication`)
- `statix check .` clean
- `nixfmt` clean
