### PR TITLE
feat(openfortivpn): add openfortivpn via homebrew

### DIFF
--- a/modules/networking/openfortivpn.nix
+++ b/modules/networking/openfortivpn.nix
@@ -1,0 +1,7 @@
+{ mkUserModule, forPlatform, ... }:
+mkUserModule {
+  name = "openfortivpn";
+  system = forPlatform {
+    darwin.homebrew.brews = [ "openfortivpn" ];
+  };
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -146,6 +146,7 @@ mkUser {
   tailscale.enable = true;
   "cloudflare-warp".enable = true;
   wireguard.enable = true;
+  openfortivpn.enable = true;
 
   # Security
   "1password".enable = true;


### PR DESCRIPTION
Adds `openfortivpn` (Fortinet SSL VPN client) as a Homebrew formula, enabled for `vega`/`fernando`.

Verified: `nix eval .#darwinConfigurations.vega.config.homebrew.brews` lists `openfortivpn`.