### PR TITLE
feat(opencode): move a session into a worktree with wtoc

### DIFF
--- a/modules/dev/opencode-manager/plugins/tmux-notifier.ts
+++ b/modules/dev/opencode-manager/plugins/tmux-notifier.ts
@@ -144,23 +144,22 @@ function sendDesktopNotification(title: string, body: string) {
   }
 }
 
-function setPaneOption(option: string, value: string) {
-  if (!TMUX_PANE) return
-  runDetached("tmux", ["set-option", "-p", "-t", TMUX_PANE, option, value])
-}
-
-// @oc-status is written from two places in the same handler, and detached
-// writes carry no ordering guarantee -- an 'idle' default landing after a
-// 'busy' would park the pane on the wrong state until the next transition.
-function setPaneOptionOrdered(option: string, value: string) {
-  if (!TMUX_PANE) return
+// Pane options are the pane's identity and status, so every write is
+// synchronous and reports whether it landed. Detached writes carry no
+// ordering or delivery guarantee: an 'idle' default arriving after a 'busy'
+// parks the pane on the wrong state, and a dropped @oc-sid leaves the pane
+// unclaimed for the whole life of the process.
+function setPaneOption(option: string, value: string): boolean {
+  if (!TMUX_PANE) return false
   try {
-    spawnSync("tmux", ["set-option", "-p", "-t", TMUX_PANE, option, value], {
+    const result = spawnSync("tmux", ["set-option", "-p", "-t", TMUX_PANE, option, value], {
       stdio: "ignore",
       timeout: 300,
     })
+    return !result.error && result.status === 0
   } catch {
     // Notifier side-effects must never break the opencode session.
+    return false
   }
 }
 
@@ -261,7 +260,7 @@ export const TmuxNotifierPlugin = async ({ client, directory }: PluginInput): Pr
   // Pane options outlive the process that wrote them, and a resumed session
   // emits no status event until it does something -- without this reset the
   // pane keeps a status from a previous process forever.
-  setPaneOptionOrdered("@oc-status", "idle")
+  setPaneOption("@oc-status", "idle")
 
   // Subagents share this pane's event stream and would steal @oc-sid. Only
   // session.created carries info.parentID; idle/status carry just a sessionID.
@@ -285,11 +284,15 @@ export const TmuxNotifierPlugin = async ({ client, directory }: PluginInput): Pr
 
   function bindSessionToPane(sessionID: string) {
     if (!TMUX_PANE || childSessions.has(sessionID) || sessionID === currentSessionID) return
+    // Latch only after the claim lands. currentSessionID short-circuits every
+    // later attempt, so latching first turns one dropped write into a pane
+    // that stays unclaimed until the process exits; bailing here lets the
+    // next session event retry.
+    if (!setPaneOption("@oc-sid", sessionID)) return
     currentSessionID = sessionID
-    setPaneOption("@oc-sid", sessionID)
     ownStatus = "idle"
     busyChildren.clear()
-    setPaneOptionOrdered("@oc-status", "idle")
+    setPaneOption("@oc-status", "idle")
     if (directory) setPaneOption("@oc-dir", directory)
   }
 
@@ -308,7 +311,7 @@ export const TmuxNotifierPlugin = async ({ client, directory }: PluginInput): Pr
     else busyChildren.add(sessionID)
 
     const effective = ownStatus === "idle" && busyChildren.size > 0 ? "busy" : ownStatus
-    setPaneOptionOrdered("@oc-status", effective)
+    setPaneOption("@oc-status", effective)
   }
 
   function clearPending(sessionID: string) {

--- a/modules/dev/opencode/opencode.nix
+++ b/modules/dev/opencode/opencode.nix
@@ -41,6 +41,7 @@ mkUserModule {
     cache = import ./cache.nix { };
     omo-gitignore = import ./omo-gitignore.nix { };
     omo = import ./omo.nix { inherit pkgs; };
+    worktree-move = import ./worktree-move.nix { };
   };
   home =
     { username, ... }:
@@ -83,6 +84,17 @@ mkUserModule {
             lin = {
               template = "!`fish -c lin`";
               description = "Load Linear issue context";
+            };
+            # Runs inside this session's pane, so wtoc reads @oc-sid from
+            # $TMUX_PANE and relocates *this* session without a picker.
+            move = {
+              template = ''
+                !`fish -c 'wtoc $ARGUMENTS'`
+
+                That is the result of moving this session to a worktree. Repeat it
+                back verbatim and do nothing else — the move already happened.
+              '';
+              description = "Move this session into a git worktree (usage: /move [-c] <name>)";
             };
           };
           permission = {

--- a/modules/dev/opencode/worktree-move.nix
+++ b/modules/dev/opencode/worktree-move.nix
@@ -1,0 +1,219 @@
+_: {
+  home =
+    { lib, userCfg, ... }:
+    lib.mkIf userCfg.worktree.enable {
+      programs.fish = {
+        functions.wtoc = ''
+          # Move this repo's opencode session into a worktree, bringing any
+          # uncommitted work along.  Fixes the "investigated on main, now I
+          # want a PR" case: opencode pins a session to the absolute directory
+          # it was created in and never re-resolves it, so resuming inside a
+          # worktree still points at the old checkout.
+          #
+          # Composes `wt` for the worktree + tmux side rather than
+          # reimplementing it, then relocates the session through opencode's
+          # own move API.
+          argparse c/changes -- $argv
+          or return 1
+
+          set -l cur_root (git rev-parse --show-toplevel 2>/dev/null)
+          or begin
+            echo "wtoc: not a git repo"
+            return 1
+          end
+
+          set -l main_root (git worktree list --porcelain | head -1 | string replace "worktree " "")
+          set -l repo_name (basename $main_root)
+          set -l wt_dir (dirname $main_root)"/$repo_name.worktrees"
+
+          set -l name $argv[1]
+          set -l branch $argv[2]
+
+          # No name: pick an existing worktree, the way `wt` with no args does.
+          if test -z "$name"
+            if not test -d "$wt_dir"; or test (count (command ls "$wt_dir" 2>/dev/null)) -eq 0
+              echo "wtoc: no worktrees yet — use: wtoc [-c] <name> [branch]"
+              return 1
+            end
+            set name (command ls "$wt_dir" | fzf --select-1 --prompt="move session to> " --height=40%)
+            or return 1
+          end
+
+          set -l wt_path "$wt_dir/$name"
+
+          if test "$wt_path" = "$cur_root"
+            echo "wtoc: already in worktree '$name'"
+            return 1
+          end
+
+          # Candidates are top-level sessions only.  Subagent sessions are
+          # children and are usually the most recently touched rows for a
+          # directory, so an unfiltered "latest session" picks the wrong one.
+          set -l db "$HOME/.local/share/opencode/opencode.db"
+          set -l rows (sqlite3 -separator \t "$db" \
+            "SELECT id, title FROM session
+             WHERE directory = '$cur_root' AND parent_id IS NULL
+             ORDER BY time_updated DESC LIMIT 20" 2>/dev/null)
+
+          if test -z "$rows"
+            echo "wtoc: no opencode session found for $cur_root"
+            return 1
+          end
+
+          set -l ids (printf '%s\n' $rows | string split -f1 \t)
+
+          # Prefer the session this tmux session is actually running (@oc-sid,
+          # bound by the notifier plugin).  It is unset for panes opencode
+          # never emitted a session.created for, and one repo can host several
+          # instances — so ask instead of guessing when it does not pin down.
+          set -l sid
+          if set -q TMUX
+            # This pane's own claim wins: exact both when run from inside
+            # opencode (its shell inherits TMUX_PANE) and when run in the pane
+            # opencode was quit in, since nothing clears @oc-sid on exit.
+            if set -q TMUX_PANE
+              set -l own (command tmux show-options -pv -t "$TMUX_PANE" @oc-sid 2>/dev/null)
+              contains -- "$own" $ids; and set sid $own
+            end
+            if test -z "$sid"
+              for pane_sid in (command tmux list-panes -s -F '#{@oc-sid}' 2>/dev/null)
+                if contains -- "$pane_sid" $ids
+                  set sid $pane_sid
+                  break
+                end
+              end
+            end
+          end
+
+          if test -z "$sid"
+            set -l pick (printf '%s\n' $rows |
+              fzf --select-1 --delimiter=\t --with-nth=2.. --prompt="move session> " --height=40%)
+            or return 1
+            set sid (string split -f1 \t -- "$pick")
+          end
+
+          set -l title (sqlite3 "$db" "SELECT title FROM session WHERE id = '$sid'" 2>/dev/null)
+          set -l dirty (git -C "$cur_root" status --porcelain | wc -l | string trim)
+
+          # Note the session we came from before wt switches away, so we can
+          # warn about a TUI left behind on the old path.
+          set -l src_session
+          if set -q TMUX
+            set src_session (command tmux display-message -p '#{session_name}')
+          end
+
+          # Worktree + tmux session, including switching to it.  Gate on the
+          # directory rather than wt's status: wt ends on switch-client, so it
+          # reports failure when no client is attached even though the
+          # worktree is fine — and the move only needs the directory.
+          wt $name $branch
+          if not test -d "$wt_path"
+            echo "wtoc: worktree '$name' was not created"
+            return 1
+          end
+
+          # ponytail: the move API needs a live server and a running TUI only
+          # serves /health on its own port, so spin a throwaway one (~1s) and
+          # kill it.  If the shared server is ever enabled
+          # (opencode.server.autoAttach), point $base at :4096 and drop this.
+          set -l port (random 40000 60000)
+          set -l log (mktemp)
+          opencode serve --port $port >$log 2>&1 &
+          set -l srv $last_pid
+
+          set -l base "http://127.0.0.1:$port"
+          set -l ready 0
+          for i in (seq 100)
+            if curl -s -m 1 -o /dev/null "$base/doc" 2>/dev/null
+              set ready 1
+              break
+            end
+            sleep 0.1
+          end
+
+          if test $ready -eq 0
+            echo "wtoc: opencode server did not start"
+            cat $log
+            kill $srv 2>/dev/null
+            rm -f $log
+            return 1
+          end
+
+          # moveChanges relocates uncommitted work and resets the source tree,
+          # so it stays opt-in (-c) — otherwise an unrelated half-finished edit
+          # in the source would be swept along.  It is applied to the
+          # destination before the move is published, so a failed apply leaves
+          # the session where it was.
+          set -l move_changes false
+          set -q _flag_changes; and set move_changes true
+
+          set -l out (mktemp)
+          set -l code (curl -s -m 120 -o $out -w '%{http_code}' \
+            -X POST "$base/experimental/control-plane/move-session" \
+            -H 'content-type: application/json' \
+            -d (printf '{"sessionID":"%s","destination":{"directory":"%s"},"moveChanges":%s}' \
+                  "$sid" "$wt_path" "$move_changes"))
+
+          kill $srv 2>/dev/null
+          rm -f $log
+
+          # The destination patch is applied before the move is published, so
+          # a failure here leaves the session and both trees untouched.
+          if test "$code" != 204
+            echo "wtoc: move failed — session stayed in $cur_root"
+            echo "  "(jq -r '.data.message // .' <$out 2>/dev/null; or cat $out)
+            rm -f $out
+            return 1
+          end
+          rm -f $out
+
+          echo "Moved \"$title\" → $name"
+          if test "$dirty" -gt 0
+            if set -q _flag_changes
+              echo "  brought $dirty uncommitted file(s) along"
+            else
+              echo "  left $dirty uncommitted file(s) behind — -c carries them over"
+            end
+          end
+
+          # A TUI that was running the session keeps its old directory in
+          # memory — it does not fail, it just silently edits the wrong tree.
+          if test -n "$src_session"
+            and command tmux list-panes -s -t "=$src_session" -F '#{pane_current_command}' 2>/dev/null |
+              string match -qr opencode
+            echo "  heads-up: opencode is still open in $src_session on the old path — close it"
+          end
+
+          if set -q TMUX
+            set -l parent (command tmux display-message -p '#{session_name}' | string split -m 1 '/')[1]
+            set -l target "=$parent/$name"
+            # wt returns early when the worktree session already exists, and
+            # that session is usually already running opencode — send-keys
+            # would type into its TUI, so take a fresh window instead.
+            if command tmux list-panes -t "$target" -F '#{pane_current_command}' 2>/dev/null |
+                string match -qr opencode
+              command tmux new-window -t "$target" -c "$wt_path" "opencode --session $sid"
+            else
+              # "=name" is a session target; send-keys resolves a pane, so it
+              # needs the trailing ":" to mean "that session's active pane".
+              command tmux send-keys -t "$target:" "opencode --session $sid" Enter
+            end
+          else
+            echo "  resume with: cd $wt_path; and opencode --session $sid"
+          end
+        '';
+
+        # Same arguments as wt: existing worktree names, then branches.
+        shellInit = ''
+          complete -f -c wtoc -s c -l changes -d "Carry uncommitted changes over to the worktree"
+          complete -f -c wtoc -n "test (count (commandline -opc)) -eq 1" -a '(
+            set -l mr (git worktree list --porcelain 2>/dev/null | head -1 | string replace "worktree " "")
+            set -l rn (basename $mr 2>/dev/null)
+            set -l wd (dirname $mr 2>/dev/null)/$rn.worktrees
+            test -d $wd 2>/dev/null; and command ls $wd 2>/dev/null
+          )'
+          complete -f -c wtoc -n "test (count (commandline -opc)) -eq 2" -a '(git branch -a --format="%(refname:short)" 2>/dev/null | string replace -r "^origin/" "" | sort -u | grep -v "^HEAD")'
+        '';
+      };
+    };
+}


### PR DESCRIPTION
Moves an opencode session into a git worktree, so investigating on main and then wanting a PR no longer means starting a fresh session there by hand.

```fish
wtoc feature-x        # create/switch worktree, move this session, reopen it there
wtoc -c feature-x     # ...and carry uncommitted changes over
wtoc                  # pick an existing worktree, like bare `wt`
/move feature-x       # same thing from inside opencode
```

## Why the session had to move this way

opencode stores an absolute `directory` on the session row and never re-resolves it, so resuming inside a worktree still points at the old checkout.

The relocation goes through `POST /experimental/control-plane/move-session` rather than updating the row directly, because the move is event-sourced — it publishes `session.next.moved` and resets `session_context_epoch`, and a raw `UPDATE` would skip both. Worktrees of one repo share a `projectID`, so the API's cross-project rejection never fires.

That endpoint needs a live server, and a running TUI only serves `/health` on its own port, so `wtoc` spins a throwaway `opencode serve` (~1s) and kills it.

## Behaviour worth knowing

- **Uncommitted changes stay put unless `-c`.** `moveChanges` relocates them *and* resets the source tree, which shouldn't happen to unrelated half-finished work by default.
- **Composes `wt`** for the worktree and tmux side instead of reimplementing it.
- **Subagent sessions are excluded** from resolution — they're usually the most recently touched rows for a directory, so an unfiltered "latest session" picks the wrong one.
- **Session resolution prefers the invoking pane's own `@oc-sid`**, exact both from inside opencode (its shell inherits `TMUX_PANE`) and from the pane opencode was quit in. Falls back to an fzf picker.

## The `@oc-sid` fix (first commit)

`@oc-sid` was written with a detached, unawaited `tmux set-option` while `@oc-status` used a synchronous one, and `bindSessionToPane` latched `currentSessionID` *before* that write. One dropped write left the pane unclaimed for the life of the process, with no retry.

Visible in the wild: a pane running an active session had `status=[busy]` but `sid=[]` — same plugin, same handler, same `TMUX_PANE` guard, only the detached write missing. Everything reading `@oc-sid` (the tmux session picker, and now `wtoc`) is blind to such a pane.

Fixed by deleting the detached writer rather than adding a third path: one synchronous writer that reports whether the write landed, with the latch moved after the claim so failures retry.

## Verification

Run against real sessions and an isolated tmux server (live sessions untouched):

- main → worktree and worktree → worktree, with and without `-c`
- conflicting destination fails **atomically** — session and both trees untouched, no stray `moved` event
- worktree session already running opencode gets a **new window** instead of `send-keys` into its TUI
- two panes claiming different sessions: the **invoking pane's** session is the one that moves
- plugin run under bun against real tmux: binding sets `@oc-sid`/`@oc-status`/`@oc-dir`; with a `tmux` stub that always exits 1, three `session.created` events produce three write attempts (previously one, then permanent silence)

Also caught two `tmux -t` target bugs by execution rather than inspection: `send-keys -t "=session"` fails for any name (needs a trailing `:`), and gating on `wt`'s exit status broke whenever no client was attached, since `wt` ends on `switch-client`.

## Known rough edge

The opencode instance that *was* running the session keeps its old directory in memory. It doesn't fail — it goes silently stale, so `wtoc` prints a heads-up and that window should be closed.

`/move` is the least-exercised path: the shell invocation and rendered config are verified, but if opencode runs commands from the main checkout rather than the session's worktree, the candidate lookup would miss from inside a worktree.
