### PR TITLE
fix(hammerspoon): stop forking duplicate app instances on launch

### DIFF
--- a/modules/darwin/hammerspoon/init.lua
+++ b/modules/darwin/hammerspoon/init.lua
@@ -189,13 +189,26 @@ local function warpToApp(bundleID, screen, tries)
   end
 end
 
--- Hyper + T → Open a new Ghostty window
--- Uses hs.task (async) to avoid blocking the main thread.
+-- Hyper + T → Open a new Ghostty window in the ALREADY-RUNNING instance.
+-- This used to shell out to `open -na Ghostty`, but -n means "new instance":
+-- every press forked another Ghostty process, so AltTab filled with duplicate
+-- windows that no amount of quitting one window would clear. The File → New
+-- Window menu item is the supported way to add a window here — ghostty's own
+-- `+new-window` action is GTK-only and exits with "not supported on this
+-- platform" on macOS.
 local tCode = hs.keycodes.map["t"]
 if tCode then
   keyCodeNames[tCode] = "t"
   hyperActionsByKeyCode[tCode] = function()
-    hs.task.new("/usr/bin/open", nil, { "-na", "Ghostty" }):start()
+    local ghostty = hs.application.get("com.mitchellh.ghostty")
+    if ghostty then
+      -- Activate first: selectMenuItem drives the AX menu bar, which is only
+      -- reliably populated for the frontmost app.
+      ghostty:activate()
+      ghostty:selectMenuItem({ "File", "New Window" })
+    else
+      hs.application.launchOrFocusByBundleID("com.mitchellh.ghostty")
+    end
     warpToApp("com.mitchellh.ghostty")
   end
 end
@@ -206,7 +219,7 @@ end
 -- session/window resolution lives in the tmux-nvim-window shell script; it
 -- runs async so a slow tmux/git can't stall the eventtap.
 local function focusNvimWindow()
-  hs.task.new("/usr/bin/open", nil, { "-a", "Ghostty" }):start()
+  hs.application.launchOrFocusByBundleID("com.mitchellh.ghostty")
   warpToApp("com.mitchellh.ghostty")
   hs.task.new("/bin/sh", nil, { "-l", "-c", "tmux-nvim-window focus" }):start()
 end
@@ -218,14 +231,14 @@ if cCode then
 end
 
 -- Toggle an app: hide it when it's frontmost, otherwise launch/focus it.
--- hide() on an already-running app is a fast AX call; launching goes through
--- hs.task (async) to avoid blocking the main thread.
-local function toggleApp(bundleID, appName)
+-- Both halves are fast AX/NSWorkspace calls, and launchOrFocusByBundleID
+-- never forks a second instance the way `open -n` does.
+local function toggleApp(bundleID)
   local front = hs.application.frontmostApplication()
   if front and front:bundleID() == bundleID then
     front:hide()
   else
-    hs.task.new("/usr/bin/open", nil, { "-a", appName }):start()
+    hs.application.launchOrFocusByBundleID(bundleID)
     warpToApp(bundleID)
   end
 end
@@ -241,7 +254,7 @@ if spaceCode then
     if front and front:bundleID() == "com.mitchellh.ghostty" then
       hs.task.new("/bin/sh", nil, { "-l", "-c", "tmux-nvim-window" }):start()
     else
-      hs.task.new("/usr/bin/open", nil, { "-a", "Ghostty" }):start()
+      hs.application.launchOrFocusByBundleID("com.mitchellh.ghostty")
       warpToApp("com.mitchellh.ghostty")
     end
   end
@@ -252,7 +265,7 @@ local iCode = hs.keycodes.map["i"]
 if iCode then
   keyCodeNames[iCode] = "i"
   hyperActionsByKeyCode[iCode] = function()
-    toggleApp("com.linear", "Linear")
+    toggleApp("com.linear")
   end
 end
 
@@ -261,7 +274,7 @@ local sCode = hs.keycodes.map["s"]
 if sCode then
   keyCodeNames[sCode] = "s"
   hyperActionsByKeyCode[sCode] = function()
-    toggleApp("com.tinyspeck.slackmacgap", "Slack")
+    toggleApp("com.tinyspeck.slackmacgap")
   end
 end
 
@@ -270,7 +283,7 @@ local oCode = hs.keycodes.map["o"]
 if oCode then
   keyCodeNames[oCode] = "o"
   hyperActionsByKeyCode[oCode] = function()
-    toggleApp("md.obsidian", "Obsidian")
+    toggleApp("md.obsidian")
   end
 end
 
@@ -283,7 +296,7 @@ if nCode then
   hyperActionsByKeyCode[nCode] = function()
     local ghostty = hs.application.get("com.mitchellh.ghostty")
     if not ghostty then
-      hs.task.new("/usr/bin/open", nil, { "-a", "Ghostty" }):start()
+      hs.application.launchOrFocusByBundleID("com.mitchellh.ghostty")
       return
     end
     ghostty:activate()


### PR DESCRIPTION
## Problem

AltTab was showing three Ghostty entries with only one window open. Not an AltTab bug — there were genuinely three Ghostty processes running, started days apart:

```
pid 1388   Fri Jul 31 09:49   windows=1
pid 3970   Thu Aug  6 11:05   windows=1
pid 95988  Fri Jul 31 12:28   windows=0
```

Root cause is the Hyper+T binding:

```lua
hs.task.new("/usr/bin/open", nil, { "-na", "Ghostty" }):start()
```

`-n` means *open a new instance*. Every Hyper+T forked another Ghostty process instead of adding a window to the running one. Quitting a window never cleared the extras because each was a separate app.

## Fix

Drop the `open` subprocesses in favour of native Hammerspoon calls.

**Hyper+T** activates the running instance and clicks `File > New Window`. Ghostty's own `+new-window` action looks like the obvious fix but is GTK-only:

```
$ ghostty +new-window
+new-window is not supported on this platform.
```

so the menu item is the supported route on macOS. `activate()` runs first because `selectMenuItem` drives the AX menu bar, which is only reliably populated for the frontmost app.

**Every other launch path** (`toggleApp`, `focusNvimWindow`, Hyper+Space, Hyper+N) moves to `hs.application.launchOrFocusByBundleID`, which activates a running app rather than spawning a second copy — and drops a subprocess spawn while it's there.

**`toggleApp` loses its `appName` parameter.** It already took a bundle ID for the frontmost check; now that it launches by bundle ID too, the second argument was pure duplication. All four bundle IDs were confirmed against each app's `Info.plist` before relying on them for launching:

| bundle ID | app |
|---|---|
| `com.mitchellh.ghostty` | Ghostty |
| `com.linear` | Linear |
| `com.tinyspeck.slackmacgap` | Slack |
| `md.obsidian` | Obsidian |

## Verification

`luac -p` on the file, plus `statix check .` and `nix flake check` (all checks passed).

Behaviour was exercised against the live Hammerspoon through its AppleScript bridge, running the new logic verbatim:

```
baseline                           instances=3 windows=3 front=com.tinyspeck.slackmacgap
after new-window #1                instances=3 windows=4 front=com.tinyspeck.slackmacgap
after new-window #2                instances=3 windows=5 front=com.mitchellh.ghostty
toggle linear (show)               front=com.linear  PASS
toggle linear (hide)               front=com.mitchellh.ghostty  PASS
toggle slack (show)                front=com.tinyspeck.slackmacgap  PASS
toggle slack (hide)                front=com.mitchellh.ghostty  PASS
toggle obsidian (show)             front=md.obsidian  PASS
toggle obsidian (hide)             front=com.mitchellh.ghostty  PASS
```

`instances` stays at 3 across two new-window calls while `windows` climbs — the old code would have taken it to 5 processes. All six show/hide toggles land on the expected frontmost app.

## After merging

The three stale Ghostty processes predate this change and won't clean themselves up. `pid 95988` has no windows and can be quit outright; the other two each hold a real window.
