### PR TITLE
fix(alt-tab): hide apps with no open window from the switcher

### DIFF
--- a/modules/darwin/alt-tab/config.plist
+++ b/modules/darwin/alt-tab/config.plist
@@ -74,6 +74,10 @@
 	<string>0</string>
 	<key>showOnScreen</key>
 	<string>1</string>
+	<key>showWindowlessApps</key>
+	<string>1</string>
+	<key>showWindowlessApps2</key>
+	<string>1</string>
 	<key>updatePolicy</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## Problem

AltTab was showing a second Google Chrome entry with no window behind it. Not an AltTab bug — there really were two Chrome processes, and one of them had no windows at all:

```
pid 9656   --profile-directory=Profile 1                    windows=3  children=100
pid 85634  --user-data-dir=.../.chrome-dev-profile-v3       windows=0  children=3
```

`pid 85634` was a leftover from the scribe extension dev launcher, running for 6d23h. Its three children are the baseline GPU/network/utility helpers — no renderers, so nothing was open in it. It still held a switcher slot.

Worth noting because it is the natural first guess: **Chrome profiles are not the cause.** Both profiles live inside a single process — `pid 9656` owned all three windows:

```
PR #9163 ... — Google Chrome — Fernando (Telepatia)
2205.03568  — Google Chrome — Fernando (Personal)
PR #9088 ... — Google Chrome — Fernando (Telepatia)
```

Chrome only forks a separate app instance when passed `--user-data-dir`, which is exactly what the extension dev launcher does. So every round of extension work can leave one of these behind.

## Root cause

AltTab has a per-shortcut preference for this, `showWindowlessApps`, which `config.plist` never set:

| value | meaning |
|---|---|
| `0` | show, in normal order |
| `1` | hide |
| `2` | show, bucketed to the end |

The shipped default is `2` ([`Preferences.swift#L54-L62`](https://github.com/lwouis/alt-tab-macos/blob/081f3ee4014e03557c2ab39e9e168dac308fa49b/src/preferences/Preferences.swift#L54-L62), [`MacroPreferences.swift#L122-L132`](https://github.com/lwouis/alt-tab-macos/blob/081f3ee4014e03557c2ab39e9e168dac308fa49b/src/preferences/MacroPreferences.swift#L122-L132)). That is why the windowless entry was always parked at the end of the switcher rather than missing — it was being shown deliberately. In the settings UI this is *"Show apps with no open window"* ([`ShortcutEditor.swift#L297-L335`](https://github.com/lwouis/alt-tab-macos/blob/081f3ee4014e03557c2ab39e9e168dac308fa49b/src/preferences/settings-window/tabs/controls/ShortcutEditor.swift#L297-L335)).

Only `1` actually filters the app out ([`WindowFilterResolver.swift#L14-L19`](https://github.com/lwouis/alt-tab-macos/blob/081f3ee4014e03557c2ab39e9e168dac308fa49b/src/switcher/state/WindowFilterResolver.swift#L14-L19)).

## Fix

```xml
<key>showWindowlessApps</key>
<string>1</string>
<key>showWindowlessApps2</key>
<string>1</string>
```

**Two keys, not one.** AltTab stores this per shortcut slot, and the suffix is the slot index — slot 0 is the bare key, slot 1 is `…2`, up to `…10` for slot 9 ([`Preferences.swift#L158-L159`](https://github.com/lwouis/alt-tab-macos/blob/081f3ee4014e03557c2ab39e9e168dac308fa49b/src/preferences/Preferences.swift#L158-L159)). This config runs two hold shortcuts:

```
shortcutCount = 2
holdShortcut  = ⌘        (slot 0)
holdShortcut2 = ⌘        (slot 1)
```

so setting only the bare key would have left the second shortcut on the default.

Values are stored as **strings**, not booleans — AltTab reads them with `string(forKey:)` and converts through `Int` ([`Preferences.swift#L501-L523`](https://github.com/lwouis/alt-tab-macos/blob/081f3ee4014e03557c2ab39e9e168dac308fa49b/src/preferences/Preferences.swift#L501-L523)). Writing a real `<true/>` would have parsed as nil and silently fallen back to the default, which matches how every other value in this plist is already stored.

## Verification

`plutil -lint config.plist` → OK.

Applied through the same path the activation script uses, quitting AltTab first so it could not flush stale in-memory prefs over the import:

```
$ killall AltTab
$ defaults import com.lwouis.alt-tab-macos modules/darwin/alt-tab/config.plist
showWindowlessApps     = 1
showWindowlessApps2    = 1

$ open -a AltTab            # re-read after AltTab's own launch migrations
showWindowlessApps     = 1
showWindowlessApps2    = 1
```

The values survive AltTab's startup migration pass, which is the part that would have caught a wrong key name or wrong value type — an unrecognised key gets dropped, and `preferencesVersion` is `11.3.0` against installed cask `alt-tab 11.3.0`.

## Follow-up, not in this PR

`config.plist` carries `appsToShow10` and `screensToShow10` alongside `appsToShow` and `screensToShow`. Under the slot-index scheme those are slot 9, which cannot be right when `shortcutCount` is 2 — and `appsToShow2`, the key slot 1 would actually use, is unset. Both `…10` keys hold the same value as their bare counterparts, which is what a migration that copied forward and orphaned the original would look like. Harmless, but they are almost certainly dead keys and could be dropped after confirming against the migration code.
