### PR TITLE
feat(worktree): namespace new branches with git config wt.prefix

### DIFF
--- a/modules/cli/worktree/worktree.nix
+++ b/modules/cli/worktree/worktree.nix
@@ -72,18 +72,18 @@ mkUserModule {
               return 1
             end
 
-            if test -n "$branch"
-              # Use existing branch, or create new branch from current
-              if git show-ref --verify --quiet "refs/heads/$branch"
-                git worktree add "$wt_path" "$branch"
-              else if git show-ref --verify --quiet "refs/remotes/origin/$branch"
-                git worktree add --track -b "$branch" "$wt_path" "origin/$branch"
-              else
-                git worktree add -b "$branch" "$wt_path" "$base_branch"
-              end
+            # No branch given: name it after the worktree, namespaced by
+            # `git config wt.prefix` (e.g. "fernando/") so it can't collide with
+            # other people's PRs. An explicit branch arg is used verbatim.
+            test -z "$branch"; and set branch (git config --default "" wt.prefix)"$name"
+
+            # Use existing branch (local, then remote), else create it from current
+            if git show-ref --verify --quiet "refs/heads/$branch"
+              git worktree add "$wt_path" "$branch"
+            else if git show-ref --verify --quiet "refs/remotes/origin/$branch"
+              git worktree add --track -b "$branch" "$wt_path" "origin/$branch"
             else
-              # New branch (named after worktree) from current branch
-              git worktree add -b "$name" "$wt_path" "$base_branch"
+              git worktree add -b "$branch" "$wt_path" "$base_branch"
             end
             or begin; echo "wt: failed to create worktree"; return 1; end
             echo "Created worktree at $wt_path (from $base_branch)"
@@ -180,9 +180,10 @@ mkUserModule {
 
           # Rename the branch only when it matches the old worktree name
           # (the auto-named case from wt), fixing the typo everywhere.
-          if test "$branch" = "$old"
-            git -C "$main_root" branch -m "$old" "$new" 2>/dev/null
-            and set branch "$new"
+          # wt.prefix is empty when unset, so this is the plain name by default.
+          set -l prefix (git config --default "" wt.prefix)
+          if test "$branch" = "$prefix$old"
+            git -C "$main_root" branch -m "$branch" "$prefix$new" 2>/dev/null
           end
 
           direnv allow "$new_path" 2>/dev/null


### PR DESCRIPTION
Shared repos hand out branch names on a first-come basis, so a worktree named
`fix-login` becomes a branch called `fix-login` that collides with whoever else
picked the obvious name. This adds an opt-in namespace, read from git config so
it stays per-repo:

```sh
git config wt.prefix fernando/
```

`wt fix-login` then creates dir `fix-login`, tmux session `<repo>/fix-login`, and
branch `fernando/fix-login`. Only the branch is namespaced — paths and session
names stay short.

Unset by default, so nothing changes unless you opt in.

## How

One line carries it:

```fish
test -z "$branch"; and set branch (git config --default "" wt.prefix)"$name"
```

`--default ""` matters: fish expands `(cmd)"$name"` to an *empty list* when the
command prints nothing, so a bare `git config wt.prefix` would silently blank the
branch name when the key is unset.

Resolving the branch up front also let the old `if test -n "$branch"` split go —
the auto-named case had its own duplicate `worktree add -b` line, and now falls
through the same local → remote → create chain as an explicit branch arg. Net
result is shorter than before.

An explicit branch arg is used verbatim, never prefixed. That's what keeps `wtl`
from turning Linear's already-namespaced `fernandobrito/tel-123-foo` into
`fernando/fernandobrito/tel-123-foo`.

`wtmv` needed a matching change: it renames the branch only when the branch
matches the old worktree name, and that comparison now accounts for the prefix.
With `wt.prefix` unset the comparison is byte-for-byte the old one.

## Verified

Ran the resolution logic against a scratch repo, both with and without the config
set:

| Input | prefix unset | `wt.prefix=fernando/` |
|---|---|---|
| `wt foo` | create `foo` | create `fernando/foo` |
| `wt foo legacy-branch` | adopt `legacy-branch` | adopt `legacy-branch` |
| `wt already` (branch exists) | — | adopts `fernando/already`, no error |
| `wtmv already renamed` | `plainname` → `renamed` | `fernando/already` → `fernando/renamed` |

That third row is the re-entrancy case: removing a worktree but keeping its
branch used to mean `wt` tried to re-create a branch that already existed.

`wtrm` and the `gmm` merge-and-cleanup path in `modules/dev/git.nix` both read the
branch back out of the worktree with `rev-parse`, so neither assumes branch name
equals worktree name and neither needed touching.

`statix` and `nixfmt` clean; fish snippets checked with `fish -n`.

## Not covered

`wts new` (`stacked.nix`) creates stack branches off trunk the same way and does
not read `wt.prefix` yet. Same one-line fix, left out to keep this focused.
