### PR TITLE
fix(tmux): report real cpu usage instead of load average

### DIFF
--- a/modules/cli/tmux/statusbar.nix
+++ b/modules/cli/tmux/statusbar.nix
@@ -14,14 +14,14 @@ let
 
       RESET="#[fg=''${FG},bg=''${BG},nobold,noitalics,nounderscore,nodim]"
 
-      # 1-minute load average as a percentage of available cores. macOS exposes
-      # no cheap instantaneous CPU%: top -l 1 costs ~1.2s and iostat -c 2 ~1.0s,
-      # both far too slow for a 5s status interval. vm.loadavg is ~18ms.
-      # ponytail: load counts runnable + uninterruptible tasks, so this reads a
-      # little higher than top's user+sys. Clamped to 100 — past saturation the
-      # backlog depth doesn't change what the widget is telling you.
+      # Sum of per-process CPU% over available cores. macOS exposes no cheap
+      # instantaneous CPU%: top -l 1 costs ~1.2s and iostat -c 2 ~1.0s, both far
+      # too slow for a 5s status interval. ps is ~30ms.
+      # ponytail: was vm.loadavg/ncpu, but macOS load counts threads that aren't
+      # running, so it pinned at 100% with the CPU 70% idle. ps pcpu is a
+      # decaying per-process average — close enough for a status bar.
       ncpu=$(sysctl -n hw.ncpu 2>/dev/null)
-      cpu=$(sysctl -n vm.loadavg 2>/dev/null | awk -v n="''${ncpu:-1}" '{ v = $2 / n * 100; printf "%.0f", (v > 100 ? 100 : v) }')
+      cpu=$(ps -Ao pcpu 2>/dev/null | awk -v n="''${ncpu:-1}" 'NR > 1 { s += $1 } END { v = s / n; printf "%.0f", (v > 100 ? 100 : v) }')
       [[ -z "''${cpu}" ]] && exit 0
 
       if (( cpu < 30 )); then


### PR DESCRIPTION
## What

The status bar CPU widget never measured CPU. It derived its percentage from the 1-minute load average divided by core count — and on macOS load average counts threads that aren't running. With ~6500 live threads on 14 cores, load sits between 14 and 35 permanently, so the widget was pinned at 100% regardless of actual usage.

#584 clamped the overflow, which stopped the widget printing `523%`. But the number being clamped was never CPU% — the clamp only made a wrong number look plausible.

Captured while the widget was showing 100%:

```
load=13.84  ncpu=14  ->  99%  ->  displayed: 100%
real cpu                            27%
```

## How

Sum `ps -Ao pcpu` across all processes, divide by core count. The clamp stays — still correct if `ps` transiently sums above core count.

## Why not `top` / `iostat`

Unchanged from #584: `top -l 1` costs ~1.2s and `iostat -c 2` ~1.0s, both far too slow for a 5s status interval. `ps -Ao pcpu` is ~30ms, the same order as the `vm.loadavg` read it replaces.

`ps` pcpu is a decaying per-process average rather than an instantaneous sample, so it lags a sharp spike by a few seconds. For a 5s status bar that's a feature — less jitter.

## Verification

Measured against `top -l 2`. Two samples, because `top -l 1` reports since-boot averages rather than instantaneous ones:

| | new widget | `top -l 2` | old (loadavg) |
|---|---|---|---|
| idle | 12% | 13% | **40%** |
| 7 of 14 cores spinning | 56-58% | 61-68% | **100%** |

- `nix build .#darwinConfigurations.vega.system` passes (shellcheck runs as part of `writeShellApplication`)
- `statix check .` clean
- `nixfmt` clean

## Follow-up

The color thresholds (green <30, yellow <60, orange <85, red) were tuned against a value that was always pinned near 100. Against real CPU% they'll sit green-to-yellow most of the time. Left as-is here; worth retuning separately once there's a feel for the new range.
