### PR TITLE
fix(tmux): switch to another session on destroy instead of detaching

### DIFF
--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -171,6 +171,14 @@ mkUserModule {
 
           set -g renumber-windows on
 
+          # Destroying a session (prefix+x on its last pane, wtrm, the picker's
+          # kill bind) switches the client to the most recently active
+          # remaining session instead of detaching — killing a worktree session
+          # drops you back on its parent rather than closing the terminal. The
+          # client still exits when nothing is left, so the last session out
+          # closes Ghostty.
+          set -g detach-on-destroy off
+
           # Renumber compacts every window with no way to exempt one, so the
           # nvim window can't just sit at a high index — it gets dragged back
           # among the real windows. Instead, re-park it last whenever a window


### PR DESCRIPTION
## Problem

`prefix+x` on a session's last pane destroys the session. With the default
`detach-on-destroy on`, tmux detaches the client — the client exits, and since
Ghostty runs `tmux-attach` as its command, the Ghostty window closes with it.

Same for `wtrm` and the session picker's kill bind: removing a worktree took the
terminal down too.

## Fix

```
set -g detach-on-destroy off
```

The client switches to the most recently active remaining session instead, so
killing a worktree session drops you back on its parent. When no sessions are
left the client still exits, so the last one out closes Ghostty.

## Verification

Tested on an isolated tmux server (`-L` socket) with a real client attached via pty:

| Case | Result |
|---|---|
| kill `parent/wt` while attached to it | client survives, lands on `parent` |
| kill the last remaining session | client exits, Ghostty closes |

`statix check .` passes.

## Not covered

Sessions that have an nvim window (created by `Hyper+C`, tagged `@nvim_window`)
survive `prefix+x` on their last *real* pane — the nvim window keeps the session
alive, so you land on nvim rather than switching sessions. Nothing is destroyed,
so `detach-on-destroy` never fires. Separate issue, left for when it bites.