### PR TITLE
feat(wispr-flow): add voice dictation app to vega

### DIFF
--- a/modules/productivity/wispr-flow.nix
+++ b/modules/productivity/wispr-flow.nix
@@ -1,0 +1,5 @@
+{ mkUserModule, ... }:
+mkUserModule {
+  name = "wispr-flow";
+  casks = [ "wispr-flow" ];
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -139,6 +139,7 @@ mkUser {
   word.enable = true;
   "windows-app".enable = true;
   granola.enable = true;
+  "wispr-flow".enable = true;
   "cold-turkey-blocker".enable = true;
   selfcontrol.enable = true;
 


### PR DESCRIPTION
Adds [Wispr Flow](https://wisprflow.ai/) — voice-to-text dictation with AI auto-editing — as a cask module, enabled for `fernando@vega`.

Two-line module matching the `granola.nix` shape; no system config or HM config needed since the cask is self-contained.

Verified: `statix check .` clean, and `nix eval` confirms `wispr-flow` lands in `darwinConfigurations.vega.config.homebrew.casks`.