### PR TITLE
feat(opencode): search session history from a tmux popup on prefix+n

### DIFF
--- a/modules/dev/opencode-manager/opencode-manager.nix
+++ b/modules/dev/opencode-manager/opencode-manager.nix
@@ -249,8 +249,9 @@ mkUserModule {
       # session picker (cli/tmux/session-picker.nix) already shows the same
       # per-session attention glyph from the same source, and worktree-per-topic
       # keeps sessions ~1:1 with opencode panes, so a second picker earned
-      # nothing. prefix+n is left unbound deliberately: muscle memory should
-      # fail loudly, not do something surprising.
+      # nothing. prefix+n has since gone to opencode session-history search
+      # (dev/opencode/session-search.nix) — a different job: searching what was
+      # said months ago, not triaging what is live now.
       bind-key 'N' run-shell -b "env TMUX_OPENCODE_CALLER_TTY='#{client_tty}' ${tmux-opencode-manager}/bin/tmux-opencode-manager notify goto"
       set-hook -g after-select-window 'run-shell -b "${tmux-opencode-manager}/bin/tmux-opencode-manager notify dismiss-target #{session_name}:#{window_index}"'
       set-hook -g client-session-changed 'run-shell -b "${tmux-opencode-manager}/bin/tmux-opencode-manager notify dismiss-target #{session_name}:#{window_index}"'

--- a/modules/dev/opencode/opencode.nix
+++ b/modules/dev/opencode/opencode.nix
@@ -42,6 +42,7 @@ mkUserModule {
     omo-gitignore = import ./omo-gitignore.nix { };
     omo = import ./omo.nix { inherit pkgs; };
     worktree-move = import ./worktree-move.nix { };
+    session-search = import ./session-search.nix { inherit pkgs; };
   };
   home =
     { username, ... }:

--- a/modules/dev/opencode/scripts/oc-search.sh
+++ b/modules/dev/opencode/scripts/oc-search.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+# Search opencode session history from a tmux popup (prefix+n).
+#
+# Two searches, deliberately kept apart:
+#   typing  fzf's own fuzzy match over the visible "time · dir · title" row.
+#           Client-side, instant, never touches the DB.
+#   ^g      SQL grep over message *bodies* — the thing fzf cannot see.
+#
+# Scope (tab cycles active → 30d → all) is a relevance filter, not a speed
+# one. Measured on a 6.7GB / 1581-root-session db, a body grep for "worktree"
+# costs 0.02s/0.47s/0.57s across the three scopes but matches 7/240/1006
+# sessions. Widening is cheap; reading 1006 hits is not. So: start narrow,
+# tab to widen when you miss.
+#
+# The 0.57s "all" figure depends entirely on the EXISTS form below. Filtering
+# on part's own columns instead (`WHERE part.time_created > ...`) full-scans
+# every row and costs 6-8s, because `part` is indexed by session_id and
+# nothing else. Narrow on `session` first, always.
+
+DB="file:$HOME/.local/share/opencode/opencode.db?mode=ro"
+
+# Popup state, reset on every open. Two files rather than one parsed blob so
+# tab can re-run the *current* grep against the next scope without the script
+# ever interpolating a user string into an fzf action body.
+SCOPE_F="${TMPDIR:-/tmp}/oc-search.scope"
+QUERY_F="${TMPDIR:-/tmp}/oc-search.query"
+
+TAB=$'\t'
+DIM=$'\033[2m'
+RST=$'\033[0m'
+GRN=$'\033[32m'
+YEL=$'\033[33m'
+
+self="$0"
+
+# Session ids currently live in a tmux pane. The opencode-manager plugin
+# stamps @oc-sid on every pane running a TUI, so "active" costs no query at
+# all — it is read straight off the tmux server.
+active_ids() {
+  tmux list-panes -a -F '#{@oc-sid}' 2>/dev/null | grep -v '^$' | sort -u || true
+}
+
+# scope name → SQL predicate over `session s`
+scope_pred() {
+  case "$1" in
+  active)
+    local ids
+    ids=$(active_ids | sed "s/.*/'&'/" | paste -sd, - || true)
+    # No live panes → match nothing, rather than silently falling back to
+    # every session (which would look like the scope quietly broke).
+    if [ -z "$ids" ]; then echo "0=1"; else echo "s.id IN ($ids)"; fi
+    ;;
+  30d) echo "s.time_updated > strftime('%s','now','-30 days')*1000" ;;
+  *) echo "1=1" ;;
+  esac
+}
+
+next_scope() {
+  case "$1" in
+  active) echo "30d" ;;
+  30d) echo "all" ;;
+  *) echo "active" ;;
+  esac
+}
+
+read_scope() { cat "$SCOPE_F" 2>/dev/null || echo active; }
+read_query() { cat "$QUERY_F" 2>/dev/null || true; }
+
+# One row per session: "<id>\t<directory>\t<display>".
+# fzf matches against the display field only (--with-nth=3), so an id or an
+# absolute path can never accidentally satisfy a fuzzy query.
+build_list() {
+  local scope="$1" query="$2" pred grep_pred esc
+  pred=$(scope_pred "$scope")
+
+  grep_pred=""
+  if [ -n "$query" ]; then
+    # SQL string escape. Without this a query containing an apostrophe
+    # ("don't") terminates the literal and the statement fails.
+    esc=${query//\'/\'\'}
+    # text+reasoning only. The other 80% of parts are tool calls and step
+    # markers, whose data is machine JSON — matching them turns a search for
+    # "zentria" into every session that merely *listed a file* containing it,
+    # and yields a snippet of raw tool envelope that reads as noise.
+    grep_pred="AND EXISTS (SELECT 1 FROM part p
+                           WHERE p.session_id = s.id
+                             AND json_extract(p.data,'\$.type') IN ('text','reasoning')
+                             AND p.data LIKE '%$esc%')"
+  fi
+
+  # Subagent sessions (parent_id NOT NULL) are 64% of all rows and are never
+  # something you resume by hand, so they are excluded outright.
+  local rows
+  rows=$(sqlite3 -separator "$TAB" "$DB" "
+    SELECT s.id,
+           s.directory,
+           strftime('%m-%d %H:%M', s.time_updated/1000, 'unixepoch', 'localtime'),
+           replace(s.directory, '$HOME', '~'),
+           s.title
+    FROM session s
+    WHERE s.parent_id IS NULL AND s.time_archived IS NULL AND $pred $grep_pred
+    ORDER BY s.time_updated DESC" 2>/dev/null) || true
+  [ -z "$rows" ] && return 0
+
+  local -A LIVE=()
+  local sid
+  while IFS= read -r sid; do
+    [ -n "$sid" ] && LIVE["$sid"]=1
+  done < <(active_ids)
+
+  local id dir when short title mark
+  while IFS="$TAB" read -r id dir when short title; do
+    [ -z "$id" ] && continue
+    # ● marks a session with a TUI already open; enter jumps to that pane
+    # instead of starting a second one on the same session.
+    if [ -n "${LIVE[$id]:-}" ]; then mark="${GRN}●${RST}"; else mark=" "; fi
+    printf '%s\t%s\t%s %s%s%s  %s%-38.38s%s  %s\n' \
+      "$id" "$dir" "$mark" "$DIM" "$when" "$RST" "$DIM" "$short" "$RST" "$title"
+  done <<<"$rows"
+}
+
+header_for() {
+  local scope="$1" q label
+  q=$(read_query)
+  label="$scope"
+  if [ -n "$q" ]; then
+    # This string is emitted inside a change-header(...) fzf action, whose body
+    # ends at the matching paren — a query containing one would truncate the
+    # header and feed fzf the remainder as bogus actions. Stripped here rather
+    # than escaped because the label is a hint; the grep itself still uses the
+    # untouched query.
+    q=${q//[()]/}
+    [ ${#q} -gt 24 ] && q="${q:0:24}…"
+    label="$scope ${YEL}· grep '$q'${RST}"
+  fi
+  printf 'scope: %s%s%s   tab widen · ^g grep bodies · ^p preview · enter open' "$GRN" "$label" "$RST"
+}
+
+case "${1:-}" in
+--list)
+  build_list "$(read_scope)" "$(read_query)"
+  exit 0
+  ;;
+
+# Advance the scope and re-run whatever grep is active. Emitted as fzf actions
+# by a transform bind, so tab never has to interpolate the query itself.
+--cycle)
+  new=$(next_scope "$(read_scope)")
+  printf '%s' "$new" >"$SCOPE_F"
+  printf 'reload(%s --list)+change-header(%s)' "$self" "$(header_for "$new")"
+  exit 0
+  ;;
+
+# Body grep. clear-query is not cosmetic: after grepping, fzf's own filter
+# would keep matching the typed term against *titles* and hide the body-only
+# hits the grep just found — the exact results you asked for.
+--grep)
+  printf '%s' "${2:-}" >"$QUERY_F"
+  printf 'reload(%s --list)+clear-query+change-header(%s)' "$self" "$(header_for "$(read_scope)")"
+  exit 0
+  ;;
+
+# The point of a body grep is seeing what was said, not a list of titles that
+# each merely contain the word somewhere. Prints the matching lines with a line
+# of context, highlighted, from the same text+reasoning parts the list query
+# used — so the preview can never show a hit the list disagrees with.
+--preview)
+  sid="${2:-}"
+  [ -z "$sid" ] && exit 0
+  sesc=${sid//\'/\'\'}
+  pq=$(read_query)
+  if [ -n "$pq" ]; then
+    qesc=${pq//\'/\'\'}
+    sqlite3 "$DB" "SELECT json_extract(data,'\$.text') FROM part
+                   WHERE session_id = '$sesc'
+                     AND json_extract(data,'\$.type') IN ('text','reasoning')
+                     AND data LIKE '%$qesc%'
+                   ORDER BY time_created LIMIT 40" 2>/dev/null |
+      grep -i -F --color=always -C1 -- "$pq" 2>/dev/null | head -200 || true
+  else
+    # No grep active: the opening exchange is the cheapest answer to "what was
+    # this session even about", which the title often does not settle.
+    sqlite3 "$DB" "SELECT json_extract(data,'\$.text') FROM part
+                   WHERE session_id = '$sesc'
+                     AND json_extract(data,'\$.type') = 'text'
+                   ORDER BY time_created LIMIT 8" 2>/dev/null | head -200 || true
+  fi
+  exit 0
+  ;;
+
+--open)
+  sid="${2:-}"
+  dir="${3:-}"
+  [ -z "$sid" ] && exit 0
+  # Already running somewhere → go to it. Launching a second TUI on a live
+  # session gives two clients fighting over the same history.
+  target=$(tmux list-panes -a \
+    -F "#{session_name}${TAB}#{window_id}${TAB}#{pane_id}${TAB}#{@oc-sid}" 2>/dev/null |
+    awk -F'\t' -v s="$sid" '$4 == s {print $1 "\t" $2 "\t" $3; exit}') || true
+  if [ -n "$target" ]; then
+    IFS="$TAB" read -r tsess twin tpane <<<"$target"
+    tmux switch-client -t "=$tsess"
+    tmux select-window -t "$twin"
+    tmux select-pane -t "$tpane"
+  else
+    # 43% of recorded directories are deleted worktrees. `new-window -c` on a
+    # missing dir does not fail — tmux silently falls back to $HOME and exits
+    # 0 — so the session would resume against the wrong tree with no warning.
+    # Resolve to the worktree's main checkout instead (same naming convention
+    # wtoc uses); it still holds the branch the work landed on.
+    if [ -n "$dir" ] && [ ! -d "$dir" ]; then
+      root=${dir%%.worktrees/*}
+      if [ "$root" != "$dir" ] && [ -d "$root" ]; then dir="$root"; else dir="$HOME"; fi
+    fi
+    # ponytail: opens in the *current* tmux session. Cross-repo hits land in
+    # the wrong session's window list; route through `wt` if that grates.
+    tmux new-window -c "$dir" "opencode --session $sid"
+  fi
+  exit 0
+  ;;
+esac
+
+# Fresh popup: always start narrow and ungrepped.
+printf 'active' >"$SCOPE_F"
+: >"$QUERY_F"
+
+list=$(build_list active "")
+[ -z "$list" ] && list=$(printf '\t\t%sno active opencode sessions — tab to widen%s' "$DIM" "$RST")
+
+# Unlike the tmux session picker this is NOT --disabled: you open it to search,
+# so typing filters immediately. tab/^g are non-printable and cannot collide.
+printf '%s\n' "$list" | fzf \
+  --ansi --no-sort --layout=reverse --cycle \
+  --delimiter='\t' --with-nth=3 \
+  --prompt='❯ ' \
+  --info=inline-right \
+  --pointer='▶' \
+  --gutter=' ' \
+  --color='pointer:green,prompt:green,info:dim,header:dim' \
+  --header="$(header_for active)" \
+  --preview "$self --preview {1}" \
+  --preview-window 'right:52%:wrap:border-left' \
+  --bind 'ctrl-p:toggle-preview' \
+  --bind "tab:transform:$self --cycle" \
+  --bind "ctrl-g:transform:$self --grep {q}" \
+  --bind "enter:become($self --open {1} {2})" \
+  --bind 'ctrl-c:abort' \
+  --bind 'esc:abort'

--- a/modules/dev/opencode/session-search.nix
+++ b/modules/dev/opencode/session-search.nix
@@ -1,0 +1,32 @@
+{ pkgs }:
+let
+  tmux-oc-search = pkgs.writeShellApplication {
+    name = "tmux-oc-search";
+    runtimeInputs = with pkgs; [
+      tmux
+      fzf
+      sqlite
+      gawk
+      gnugrep
+      gnused
+      coreutils
+    ];
+    text = builtins.readFile ./scripts/oc-search.sh;
+  };
+in
+{
+  home =
+    { lib, userCfg, ... }:
+    lib.mkIf userCfg.tmux.enable {
+      home.packages = [ tmux-oc-search ];
+
+      programs.tmux.extraConfig = ''
+        # Search opencode session history. Reclaims prefix+n, which the
+        # opencode-manager module freed when its browse-all popup became
+        # prefix+N (drain the notification queue). Reading history and
+        # answering "who needs me now" are different jobs; only the second
+        # one wanted a queue.
+        bind-key 'n' display-popup -E -w 70% -h 60% '${tmux-oc-search}/bin/tmux-oc-search'
+      '';
+    };
+}


### PR DESCRIPTION
opencode 1.18 keeps every session in one SQLite db (6.7GB, 1581 root sessions here), so "which session was that in" is a query, not a grep. `prefix+n` opens an fzf popup over it.

```
❯                                          22/22 │   ▶ mo-config-options  Add Zentria medical orders options to UI
─────────────────────────────────────────────────│     monobloco           Backend architecture review
 scope: all · grep 'zentria'  tab widen · ^g …   │ --
▶ ● 08-07 23:31 ~/nix-config      opencode sear··│   ● 08-07 17:07 ~/…/mo-zentria  Zentria medical order template gaps
  ● 08-07 23:31 ~/…/mo-zentria    Zentria medic··│ --
    08-07 16:57 ~/…/mo-zentria    Adding ZENTRI··│ | `^g` grep "zentria" at active | 6/6, header updated |
```

- **type** — fuzzy over time/dir/title, client-side, never touches the db
- **tab** — widen scope: active → 30d → all
- **^g** — SQL grep over message bodies; preview shows the matching lines
- **^p** — toggle preview
- **enter** — jump to the session's pane if it is already open, else new window in its directory

## Two things that are load-bearing

**Narrow `session` before touching `part`.** `part` is indexed by `session_id` and nothing else, so the obvious time filter is a trap:

| body grep for "worktree" | |
|---|---|
| `WHERE part.time_created > 7d ago` | 5.98s |
| `WHERE EXISTS (… p.session_id = s.id)` at 30d | 0.47s |
| same, all 1581 sessions | 0.57s |

**Scope is a relevance filter, not a speed one.** That same grep matches 7 / 240 / 1006 sessions across the three scopes. Widening is cheap; reading 1006 hits is not. So it opens narrow and `tab` widens when you miss.

## Smaller decisions

- Grep covers `text` and `reasoning` parts only. The other 80% are tool envelopes and step markers — machine JSON that matched sessions which merely *listed* a file containing the word, and previewed as raw envelope. Cut "zentria" from 53 sessions to 22.
- Subagent sessions (`parent_id IS NOT NULL`) are excluded — 64% of rows, never resumed by hand.
- **43% of recorded directories are deleted worktrees.** `tmux new-window -c <missing>` does not fail — it silently falls back to `$HOME` and exits 0, which would resume a session against the wrong tree with no warning. A dead path now resolves to the worktree's main checkout (672 of 688 rescued).
- A `)` in the grep term used to truncate fzf's `change-header(...)` action body; the header label is stripped of parens, the grep itself uses the untouched query.

## Reclaims prefix+n

Freed in #587, which moved the browse-all popup to `prefix+N` (drain notifications) and left `n` unbound on purpose. Different job: this searches what was said months ago, that one triages what is live now. The stale comment in `opencode-manager.nix` is updated.

## Test

```
sudo darwin-rebuild switch --flake .#vega
```

`prefix+n`, then `^g` with a word you remember. Verified end-to-end against the built store binary in a 190-col tmux session: scope ladder 8 → 331 → 1582, grep counts matching direct SQL exactly (137/137 for "hammerspoon"), preview rendering matched lines with context. shellcheck (pre-commit and at build via `writeShellApplication`), nixfmt, statix, `nix build` all clean.
