### PR TITLE
feat(worktree): apply wt.prefix across wtpr/wts and strip it from names

### DIFF
--- a/modules/cli/worktree/pr.nix
+++ b/modules/cli/worktree/pr.nix
@@ -126,9 +126,10 @@
       # huge tmux session labels that long branch names produce. The
       # branch itself is unchanged — checkout/tracking below uses
       # $head_branch; only the worktree dir + session label differ.
-      # Sanitized branch (slashes → dashes) is offered as the default.
+      # Sanitized branch (our wt.prefix dropped, slashes → dashes) is the
+      # default, so my own "fernando/fix-foo" opens as just "fix-foo".
       if test -z "$name"
-        set -l default_name (string replace -a '/' '-' -- $head_branch)
+        set -l default_name (_wt_name $head_branch)
         read -P "wtpr: worktree name [$default_name]: " name
         or return 1
         test -z "$name"; and set name $default_name
@@ -172,9 +173,10 @@
         else
           # Fork PR: no push access, and the fork's head branch name may
           # collide locally (e.g. a fork's `main`). Fetch pull/N/head into
-          # a namespaced pr-N branch; re-running wtpr refreshes force-pushed
-          # PRs. The + forces fast-forward to handle force-pushes.
-          set -l local_branch "pr-$pr_num"
+          # a namespaced pr-N branch (under wt.prefix, like every branch wt
+          # invents); re-running wtpr refreshes force-pushed PRs. The +
+          # forces fast-forward to handle force-pushes.
+          set -l local_branch (_wt_prefix)"pr-$pr_num"
           git fetch origin "+pull/$pr_num/head:refs/heads/$local_branch" 2>/dev/null
           or begin; echo "wtpr: failed to fetch PR"; return 1; end
 

--- a/modules/cli/worktree/stacked.nix
+++ b/modules/cli/worktree/stacked.nix
@@ -251,7 +251,9 @@ in
 
           git fetch origin 2>/dev/null
           set -l trunk (_wts_trunk)
-          git worktree add -b $name "$ws_path" "origin/$trunk"
+          # Namespace the branch with wt.prefix (like wt); the worktree dir and
+          # tmux session keep the short name.
+          git worktree add -b (_wt_prefix)"$name" "$ws_path" "origin/$trunk"
           or begin
             echo "wts new: git worktree add failed" >&2
             return 1
@@ -345,7 +347,7 @@ in
           # (sanitized) as default — short names avoid huge tmux session labels.
           set -l name $argv[2]
           if test -z "$name"
-            set -l default_name (string replace -a '/' '-' -- $heads[$si])
+            set -l default_name (_wt_name $heads[$si])
             read -P "wts pr: worktree name [$default_name]: " name
             or return 1
             test -z "$name"; and set name $default_name

--- a/modules/cli/worktree/worktree.nix
+++ b/modules/cli/worktree/worktree.nix
@@ -18,6 +18,20 @@ mkUserModule {
   home = {
     programs.fish = {
       functions = {
+        # Namespace for branches the wt family invents (`git config wt.prefix`,
+        # e.g. "fernando/"), so they can't collide with other people's PRs.
+        # Empty when unset, which makes every call site a no-op by default.
+        _wt_prefix = ''
+          git config --default "" wt.prefix
+        '';
+
+        # Worktree/session name for a branch: drop our own prefix, then slashes
+        # → dashes. "fernando/fix-foo" → "fix-foo", but someone else's
+        # "alice/fix" stays "alice-fix" (whose branch it is still reads).
+        _wt_name = ''
+          string replace -r "^"(string escape --style=regex -- (_wt_prefix)) "" -- $argv[1] | string replace -a / -
+        '';
+
         wt = ''
           set git_root (git rev-parse --show-toplevel 2>/dev/null)
           or begin; echo "wt: not a git repo"; return 1; end
@@ -73,9 +87,9 @@ mkUserModule {
             end
 
             # No branch given: name it after the worktree, namespaced by
-            # `git config wt.prefix` (e.g. "fernando/") so it can't collide with
-            # other people's PRs. An explicit branch arg is used verbatim.
-            test -z "$branch"; and set branch (git config --default "" wt.prefix)"$name"
+            # wt.prefix so it can't collide with other people's PRs. An
+            # explicit branch arg is used verbatim.
+            test -z "$branch"; and set branch (_wt_prefix)"$name"
 
             # Use existing branch (local, then remote), else create it from current
             if git show-ref --verify --quiet "refs/heads/$branch"
@@ -181,7 +195,7 @@ mkUserModule {
           # Rename the branch only when it matches the old worktree name
           # (the auto-named case from wt), fixing the typo everywhere.
           # wt.prefix is empty when unset, so this is the plain name by default.
-          set -l prefix (git config --default "" wt.prefix)
+          set -l prefix (_wt_prefix)
           if test "$branch" = "$prefix$old"
             git -C "$main_root" branch -m "$branch" "$prefix$new" 2>/dev/null
           end


### PR DESCRIPTION
#590 added `wt.prefix` but only wired it into `wt`, and closed with a "not
covered" note. This is that note, plus the other half of the problem: names
derived *from* a branch kept the prefix in them.

```sh
git config wt.prefix fernando/
```

With that set, `wtpr` on my own `fernando/fix-login` now offers `fix-login` as
the worktree name instead of `fernando-fix-login`, and `wts new foo` creates
branch `fernando/foo`. Unset by default, so nothing changes unless you opt in.

## How

Two fish helpers in `worktree.nix`, so the logic has one home:

```fish
_wt_prefix   # git config --default "" wt.prefix
_wt_name     # drop our own prefix, then / → -
```

`_wt_name` is the new half. It strips *anchored* and only strips your own
prefix, so `fernando/fix-foo` → `fix-foo` while `alice/fix` stays `alice-fix` —
whose branch it is still reads at a glance in the session list.

```fish
string replace -r "^"(string escape --style=regex -- (_wt_prefix)) "" -- $argv[1] | string replace -a / -
```

`string escape --style=regex` on an empty prefix yields an empty line, leaving
`^` → `""`, a no-op. That's why there's no `test -n` guard.

Call sites:

| Site | Before | After |
|---|---|---|
| `wtpr` default name | `fernando-fix-foo` | `fix-foo` |
| `wtpr` fork branch | `pr-123` | `fernando/pr-123` |
| `wts new foo` branch | `foo` | `fernando/foo` (dir stays `foo`) |
| `wts pr` default name | `fernando-fix-foo` | `fix-foo` |
| `wt`, `wtmv` | inline `git config` | `_wt_prefix` |

`wtpr`'s fork branch is the only branch `wtpr` invents; a same-repo PR keeps its
real head branch name, unprefixed, so `git push`/`git pull` still work.

## Not touched

`wtl`/`wtlc` pass Linear's branch explicitly and `wt` never prefixes an explicit
branch arg, so `fernandobrito/tel-123-foo` stays intact. `wtoc` delegates to
`wt`. `wtrm` and `gmm` read the branch back out with `rev-parse`, so neither
assumes branch name equals worktree name.

## Verified

Against a scratch repo, with and without the config set:

| Input | prefix unset | `wt.prefix=fernando/` |
|---|---|---|
| `_wt_name fernando/fix-foo` | `fernando-fix-foo` | `fix-foo` |
| `_wt_name alice/fix` | `alice-fix` | `alice-fix` |
| `_wt_name fernando/a/b` | `fernando-a-b` | `a-b` |
| `-b (_wt_prefix)"foo"` | `-b foo` (2 args) | `-b fernando/foo` |
| real `git worktree add -b` | `foo` | `fernando/foo` |

That fourth row is the fish trap #590 called out: an empty command
substitution expands to an empty *list*, which would drop the argument
entirely. `--default ""` prints a newline, so the arg count stays 2.

All 7 touched functions were evaluated out of the built config
(`nix eval …programs.fish.functions.<fn>`) and checked with `fish -n`.
`statix` and `nixfmt` clean.
