### PR TITLE
feat(tmux): reuse an idle window on prefix+c instead of stacking duplicates

### DIFF
--- a/modules/cli/tmux/new-window.test.sh
+++ b/modules/cli/tmux/new-window.test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Self-check for prefix+c window reuse. Extracts the shell body verbatim from
+# tmux.nix (so it cannot drift) and drives it against a throwaway tmux server
+# on a private socket.
+#
+# Worth testing because every way this breaks looks like the OLD behaviour: a
+# typo in the nested #{&&:} filter matches nothing, the script falls through to
+# new-window, and you get a fresh window every time — exactly what you got
+# before, so nothing looks wrong. The failure is silent by construction.
+# Run by hand: bash new-window.test.sh
+set -eu
+
+SRC="$(cd "$(dirname "$0")" && pwd)/tmux.nix"
+REAL_TMUX=$(command -v tmux)
+
+PROG=$(awk '
+  /tmux-new-window = pkgs.writeShellApplication/ { w = 1 }
+  w && /text = \047\047/ { c = 1; next }
+  c && /^    \047\047;$/ { exit }
+  c { print }
+' "$SRC")
+
+[[ -z "$PROG" ]] && {
+  echo "FAIL: could not extract tmux-new-window body from $SRC"
+  exit 1
+}
+
+# Undo Nix's ''${...} escaping so the body is runnable bash.
+PROG=${PROG//\'\'\$\{/\$\{}
+
+command -v fish >/dev/null || {
+  echo "SKIP: fish not on PATH (the filter matches on pane_current_command)"
+  exit 0
+}
+
+TMP=$(mktemp -d)
+SOCK="$TMP/sock"
+PROJ="$TMP/proj"
+OTHER="$TMP/other"
+mkdir -p "$PROJ" "$OTHER" "$TMP/bin"
+# macOS puts mktemp dirs under the /var -> /private/var symlink; tmux reports
+# the physical path, so pin the expectations to it.
+PROJ=$(cd "$PROJ" && pwd -P)
+OTHER=$(cd "$OTHER" && pwd -P)
+
+# Invoked by trap, which shellcheck cannot see.
+# shellcheck disable=SC2329
+cleanup() {
+  "$REAL_TMUX" -S "$SOCK" kill-server 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Shim every `tmux` call in the body onto the private socket, and stub the
+# git-root helper (resolution is its own concern, not this script's).
+cat >"$TMP/bin/tmux" <<EOF
+#!/bin/sh
+exec "$REAL_TMUX" -S "$SOCK" "\$@"
+EOF
+cat >"$TMP/bin/tmux-git-root-path" <<'EOF'
+#!/bin/sh
+echo "${1:-.}"
+EOF
+chmod +x "$TMP/bin/tmux" "$TMP/bin/tmux-git-root-path"
+export PATH="$TMP/bin:$PATH"
+
+# fish explicitly for window 1 (default-command only applies to windows created
+# after it is set) and as default-command for the ones the body creates.
+tmux -f /dev/null new-session -d -s t -c "$PROJ" fish
+tmux set -g default-command fish
+# Panes report their real command only once the shell has exec'd.
+for _ in $(seq 30); do
+  [[ "$(tmux display-message -p -t t '#{pane_current_command}')" == "fish" ]] && break
+  sleep 0.1
+done
+
+count() { tmux list-windows -t t -F '#{window_id}' | wc -l | tr -d ' '; }
+# eval runs in the function's scope, so the body sees $1/$2 as its own args.
+run() { (cd "$PROJ" && eval "$PROG"); }
+
+fail=0
+check() {
+  local label=$1 expect=$2 got=$3
+  if [[ "$expect" == "$got" ]]; then
+    echo "ok   $label"
+  else
+    echo "FAIL $label: expected $expect, got $got"
+    fail=1
+  fi
+}
+
+# 1. Sitting on the only (idle) window: prefix+c must not stack a duplicate.
+run "$PROJ" t >/dev/null
+check "idle window at same root is reused, not duplicated" 1 "$(count)"
+
+# 2. A window running something is not idle — but the idle one is still found
+#    from it, rather than a third window being created.
+tmux new-window -t t: -c "$PROJ" 'sleep 60'
+busy=$(tmux display-message -p -t t '#{window_id}')
+run "$PROJ" t >/dev/null
+check "busy window does not block reuse" 2 "$(count)"
+check "reuse selects the idle window, not the busy one" \
+  "$(tmux list-windows -t t -F '#{window_id}' | head -1)" \
+  "$(tmux display-message -p -t t '#{window_id}')"
+
+# 3. A different root has no idle window, so one is created.
+tmux select-window -t "$busy"
+run "$OTHER" t >/dev/null
+check "different root creates a new window" 3 "$(count)"
+
+# 4. The new window is at the requested root.
+check "new window opens at the requested root" "$OTHER" \
+  "$(tmux display-message -p -t t '#{pane_current_path}')"
+
+exit "$fail"

--- a/modules/cli/tmux/scripts/cheatsheet.sh
+++ b/modules/cli/tmux/scripts/cheatsheet.sh
@@ -43,7 +43,8 @@ trap 'rm -f "$CONTENT"' EXIT
   sep
 
   header "Windows"
-  key "prefix c" "new window"
+  key "prefix c" "new window (reuses an empty one)"
+  key "prefix C" "new window (always creates)"
   key "prefix ," "rename window"
   key "prefix n / p" "next / previous window"
   key "prefix 1-9" "go to window #"

--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -22,6 +22,48 @@ let
     '';
   };
 
+  # prefix+c, but idempotent. A single-pane window already sitting at a shell
+  # prompt in the same git root IS what prefix+c would create, so select it
+  # instead of stacking a duplicate — the reason a session drifts to two or
+  # three identical empty windows nobody remembers opening.
+  #
+  # "Idle" is decided by pane_current_command: a window running anything
+  # (nvim, opencode, a build) reports that command and never matches, so this
+  # can only ever land you on a bare prompt. The path test keeps it from
+  # teleporting across projects when a session spans more than one root.
+  # prefix+C keeps the old always-create behavior.
+  tmux-new-window = pkgs.writeShellApplication {
+    name = "tmux-new-window";
+    runtimeInputs = [
+      pkgs.tmux
+      tmux-git-root-path
+    ];
+    text = ''
+      root=$(tmux-git-root-path "''${1:-.}")
+      # pane_current_path is always the physical path, and macOS symlinks /tmp
+      # and /var (plus any symlinked checkout), so compare like with like —
+      # otherwise the match silently never fires and this degrades back into
+      # plain new-window with no visible symptom.
+      root=$(cd "$root" 2>/dev/null && pwd -P || echo "$root")
+      session="''${2:-$(tmux display-message -p '#{session_id}')}"
+
+      # fish is default-command below, so an idle pane reports exactly "fish".
+      # Nested #{&&:} because tmux formats have no n-ary and.
+      filter="#{&&:#{==:#{window_panes},1},#{&&:#{==:#{pane_current_command},fish},#{==:#{pane_current_path},$root}}}"
+      idle=$(tmux list-windows -t "$session" -F '#{window_id}' -f "$filter" 2>/dev/null | head -1)
+
+      if [ -z "$idle" ]; then
+        tmux new-window -t "$session:" -c "$root"
+      elif [ "$idle" = "$(tmux display-message -p -t "$session" '#{window_id}' 2>/dev/null)" ]; then
+        # Selecting the window you are already on is a silent no-op, which
+        # reads as a dead keybind. Say so, and advertise the escape hatch.
+        tmux display-message "already on an empty window — prefix+C forces a new one"
+      else
+        tmux select-window -t "$idle"
+      fi
+    '';
+  };
+
   tmux-attach = pkgs.writeShellApplication {
     name = "tmux-attach";
     bashOptions = [ ];
@@ -139,6 +181,7 @@ mkUserModule {
       home.packages = [
         tmux-git-root-path
         tmux-attach
+        tmux-new-window
         tmux-nvim-window
         tmux-nvim-park
       ];
@@ -204,8 +247,12 @@ mkUserModule {
           # Reload config with prefix + R
           bind-key R source-file ~/.config/tmux/tmux.conf \; display-message "Config reloaded"
 
-          # New windows open at nearest git root; panes inherit current directory
-          bind-key c run-shell 'tmux new-window -c "$(${tmux-git-root-path}/bin/tmux-git-root-path "#{pane_current_path}")"'
+          # New windows open at nearest git root; panes inherit current directory.
+          # prefix+c reuses an idle window at that root if one exists (see
+          # tmux-new-window); prefix+C always creates, mirroring the s/S split.
+          # C was tmux's customize-mode, still reachable via prefix+: .
+          bind-key c run-shell '${tmux-new-window}/bin/tmux-new-window "#{pane_current_path}" "#{session_id}"'
+          bind-key C run-shell 'tmux new-window -t "#{session_id}:" -c "$(${tmux-git-root-path}/bin/tmux-git-root-path "#{pane_current_path}")"'
           bind-key '"' split-window -c "#{pane_current_path}"
           bind-key % split-window -h -c "#{pane_current_path}"
 


### PR DESCRIPTION
`prefix+c` always created, so a session drifts to two or three identical empty windows nobody remembers opening. `telepatia` had windows 4 and 5 both sitting at a fish prompt in the same directory.

## Behavior

| bind | what it does |
|---|---|
| `prefix+c` | reuse an idle window at this git root, else create one |
| `prefix+C` | always create (was tmux's `customize-mode`, still on `prefix+:`) |

A window counts as idle when it is single-pane, at a bare fish prompt, and at the same git root. Idleness is decided by `pane_current_command`, so a window running anything — nvim, opencode, a build — reports that command and never matches. This can only ever land you on an empty prompt, never interrupt work. The root test keeps it from teleporting across projects when a session spans more than one.

Selecting the window you are already on is a silent no-op, which reads as a dead keybind, so that case says so and advertises `prefix+C`.

Checked against live sessions before/after:

- `telepatia` → reuses window 4 (the 4/5 duplicate above)
- `automatta` → reuses window 1
- `nix-config` → creates new, nothing idle there (opencode + nvim only)

## Why a script instead of extending the inline binding

The filter has to reach `list-windows -f` as a literal string. tmux expands `#{...}` in a `run-shell` argument first, so inline it collapses against the current pane before the shell sees it:

```
run-shell 'echo "[#{&&:#{==:#{window_panes},1},#{==:#{pane_current_command},fish}}]"'
→ shell received: [0]
```

Escaping six nested `#{` as `##{`, inside a Nix string that already escapes `''${}`, would work and would be unmaintainable. As a `writeShellApplication` it also gets build-time shellcheck — `extraConfig` is opaque text to Nix, same trap `CLAUDE.md` calls out for embedded Lua — and it can be driven under test.

Consistent with the rest of the module: `tmux-nvim-window`, `tmux-nvim-park`, `tmux-group`, `tmux-pocket`, `tmux-wt-pick` are all scripts; inline `run-shell` is reserved for one-liners like `prefix+"` and `prefix+%`.

## Test

`new-window.test.sh` extracts the script body verbatim from `tmux.nix` (so it cannot drift, same approach as `statusbar.test.sh`) and drives it against a throwaway tmux server on a private socket. 5 checks: reuse, no duplicate, busy window ignored, different root creates, new window lands at the requested root.

It earned its keep immediately — it caught a bug where `pane_current_path` is always the physical path while macOS symlinks `/tmp` and `/var`, so the raw root never matched. Fixed with `pwd -P` normalization. Worth noting that **every failure mode here produces a fresh window**, which is exactly what the old binding did — a broken filter looks identical to working code.

```
$ bash modules/cli/tmux/new-window.test.sh
ok   idle window at same root is reused, not duplicated
ok   busy window does not block reuse
ok   reuse selects the idle window, not the busy one
ok   different root creates a new window
ok   new window opens at the requested root
```

Run by hand like `statusbar.test.sh`; not wired into `nix flake check`.

## Checks

`statix` clean · `nixfmt` clean · `shellcheck` clean · pre-commit passed · `nix build --dry-run` evaluates · `tmux-new-window.drv` builds.
