### PR TITLE
fix(opencode): stay silent while subagents are still running

### DIFF
--- a/modules/dev/opencode-manager/plugins/tmux-notifier.check.ts
+++ b/modules/dev/opencode-manager/plugins/tmux-notifier.check.ts
@@ -1,7 +1,8 @@
 // Run: bun run modules/dev/opencode-manager/plugins/tmux-notifier.check.ts
 //
-// Covers only @oc-status: the pane must read busy while a subagent works,
-// even though the parent session itself went idle to wait for it.
+// Covers @oc-status and the completion notification: the pane must read busy
+// -- and stay silent -- while a subagent works, even though the parent session
+// itself went idle to wait for it.
 import assert from "assert";
 import { spawnSync } from "child_process";
 import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
@@ -13,9 +14,14 @@ import { join } from "path";
 // process.env, hence the re-exec instead of an in-process mutation.
 if (!process.env.OC_CHECK_DIR) {
   const dir = mkdtempSync(join(tmpdir(), "tmux-notifier-check-"));
-  const fakeTmux = join(dir, "tmux");
-  writeFileSync(fakeTmux, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${join(dir, "tmux.log")}\nexit 0\n`);
-  chmodSync(fakeTmux, 0o755);
+  for (const [bin, log] of [
+    ["tmux", "tmux.log"],
+    ["tmux-opencode-manager", "notify.log"],
+  ]) {
+    const path = join(dir, bin);
+    writeFileSync(path, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${join(dir, log)}\nexit 0\n`);
+    chmodSync(path, 0o755);
+  }
   const { status } = spawnSync(process.execPath, [import.meta.path], {
     stdio: "inherit",
     env: {
@@ -33,13 +39,17 @@ if (!process.env.OC_CHECK_DIR) {
 }
 
 const log = join(process.env.OC_CHECK_DIR, "tmux.log");
+const notifyLog = join(process.env.OC_CHECK_DIR, "notify.log");
 writeFileSync(log, "");
+writeFileSync(notifyLog, "");
 
 const { default: TmuxNotifierPlugin } = await import("./tmux-notifier.ts");
 
 const client = {
   session: {
-    get: async () => ({ data: { title: "check", parentID: null } }),
+    get: async ({ path }: { path: { id: string } }) => ({
+      data: { title: "check", parentID: path.id.startsWith("child") ? "parent" : null },
+    }),
     messages: async () => ({ data: [] }),
   },
 };
@@ -72,6 +82,25 @@ await emit("session.status", { sessionID: "child2", status: { type: "busy" } });
 assert.strictEqual(paneStatus(), "busy", "second child busy");
 await emit("session.error", { sessionID: "child2", error: { name: "MessageAbortedError" } });
 assert.strictEqual(paneStatus(), "idle", "cancelled child releases the pane");
+
+// fireTmuxNotify spawns detached, so writes land well after emitComplete
+// returns: drain the previous round before truncating, or its notification
+// shows up as this round's.
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function notifiesOnParentIdle(): Promise<boolean> {
+  await sleep(400);
+  writeFileSync(notifyLog, "");
+  await emit("session.idle", { sessionID: "parent" });
+  await sleep(400);
+  return readFileSync(notifyLog, "utf8").includes("--event complete");
+}
+
+await emit("session.created", { info: { id: "child3", parentID: "parent" } });
+await emit("session.status", { sessionID: "child3", status: { type: "busy" } });
+assert.ok(!(await notifiesOnParentIdle()), "silent while a subagent is still running");
+
+await emit("session.idle", { sessionID: "child3" });
+assert.ok(await notifiesOnParentIdle(), "notifies once every subagent settled");
 
 console.log("tmux-notifier check: ok");
 process.exit(0);

--- a/modules/dev/opencode-manager/plugins/tmux-notifier.ts
+++ b/modules/dev/opencode-manager/plugins/tmux-notifier.ts
@@ -7,8 +7,8 @@
 //   OPENCODE_TMUX_NOTIFIER_SOUND=0       disable sound
 //   OPENCODE_TMUX_NOTIFIER_DESKTOP=0     disable desktop notifications
 //   OPENCODE_TMUX_NOTIFIER_OMO_FILTER=0  allow OMO turns to notify
-//   OPENCODE_TMUX_NOTIFIER_BG_FILTER=0   allow notifications when waiting on
-//                                        spawned background task() agents
+//   OPENCODE_TMUX_NOTIFIER_BG_FILTER=0   allow notifications while subagents
+//                                        are still running
 //   OPENCODE_TMUX_NOTIFIER_IDLE_DELAY_MS=1500
 //                                        debounce window before firing on idle.
 //                                        Larger values give OMO directives
@@ -338,6 +338,10 @@ export const TmuxNotifierPlugin = async ({ client, directory }: PluginInput): Pr
   async function emitComplete(sessionID: string) {
     const { title, isChild } = await getSessionInfo(client, sessionID)
     if (isChild) return
+    // Live child state, same signal the pane's busy colour uses. The message
+    // scan below only sees the newest assistant message, so a subagent spawned
+    // a message or two ago is invisible to it -- this catches those.
+    if (BG_FILTER_ENABLED && busyChildren.size > 0) return
     if (await isLastUserMessageFromOmo(client, sessionID)) return
     if (await isWaitingOnBackgroundTasks(client, sessionID)) return
     const body = `Session has finished${buildSuffix(title)}`


### PR DESCRIPTION
The notifier plays the completion sound when the parent session goes idle
while background subagents are still working.

## Why

`emitComplete()` gated on `isWaitingOnBackgroundTasks()`, which scans the
**newest assistant message** for a `task(run_in_background: true)` part.
That only catches the turn that launched the agents:

1. Parent fires two background agents, ends its turn → suppressed, correct.
2. Agent A finishes, wakes the parent.
3. Parent writes a new message, goes idle.
4. Newest assistant message has no `task` part → **beeps**, while agent B is
   still running.

## Fix

The plugin already tracks live child state in `busyChildren` — it is the
signal that keeps `@oc-status` on `busy` in exactly this situation, it just
was never consulted before notifying. One line in `emitComplete()`:

```ts
if (BG_FILTER_ENABLED && busyChildren.size > 0) return
```

The message scan stays as a guard for the launch race, where a child has
been spawned but has not reported `busy` yet within the 1500ms idle
debounce. Both sit behind `BG_FILTER_ENABLED`, so
`OPENCODE_TMUX_NOTIFIER_BG_FILTER=0` still means "notify anyway".

## Check

`tmux-notifier.check.ts` grew a notification assertion: silent on parent
idle with a child busy, notifying once the child settles. Verified it fails
with the fix reverted.

The fake `tmux-opencode-manager` on `PATH` records what `fireTmuxNotify`
spawns. Those spawns are detached and land well after `emitComplete()`
returns, so each round drains before truncating the log — otherwise the
previous round's notification is read as this one's and the assertion
passes while broken.

```
bun run modules/dev/opencode-manager/plugins/tmux-notifier.check.ts
tmux-notifier check: ok
```
