### PR TITLE
fix(opencode): keep throwaway sessions out of the session pickers

### DIFF
--- a/modules/dev/lazygit.nix
+++ b/modules/dev/lazygit.nix
@@ -10,14 +10,17 @@ mkUserModule {
           {
             key = "<c-a>";
             context = "files";
-            command = ''opencode run -m "anthropic/claude-haiku-4-5" "Look at the staged changes and create a commit following conventional commit conventions. Just commit directly."'';
+            # --title tags the session with its origin. These runs need the repo
+            # cwd to see staged changes, so unlike `lin ai` they cannot be parked
+            # in a scratch dir and will show up in this project's session picker.
+            command = ''opencode run --title "lazygit commit" -m "anthropic/claude-haiku-4-5" "Look at the staged changes and create a commit following conventional commit conventions. Just commit directly."'';
             output = "terminal";
             description = "Generate commit with OpenCode";
           }
           {
             key = "H";
             context = "global";
-            command = ''opencode run -m "anthropic/claude-haiku-4-5" "{{.Form.Prompt}}"'';
+            command = ''opencode run --title "lazygit: {{.Form.Prompt}}" -m "anthropic/claude-haiku-4-5" "{{.Form.Prompt}}"'';
             output = "terminal";
             description = "AI help (haiku)";
             prompts = [

--- a/modules/dev/linear.nix
+++ b/modules/dev/linear.nix
@@ -451,8 +451,13 @@ mkUserModule {
                                         set -l errfile (mktemp)
                                         set -l promptfile (mktemp)
                                         printf '%s' "$prompt" > $promptfile
+                                        # --dir: run in an empty non-repo dir so the throwaway session lands in
+                                        # opencode's "global" project instead of the picker of whatever repo we're in.
+                                        # The prompt is self-contained, so no repo context is lost.
+                                        # --title: without it these sessions are named "New session - <timestamp>".
+                                        set -l _ai_title (string shorten -m 70 -- (string replace -a \n " " -- "$task"))
                                         gum spin --spinner dot --title "Generating issue with AI..." -- \
-                                          sh -c 'opencode run -m "anthropic/claude-haiku-4-5" "$(cat "$1")" > "$2" 2> "$3"' _ "$promptfile" "$tmpfile" "$errfile"
+                                          sh -c 'd="$HOME/.local/share/lin/scratch"; mkdir -p "$d"; opencode run --dir "$d" --title "$4" -m "anthropic/claude-haiku-4-5" "$(cat "$1")" > "$2" 2> "$3"' _ "$promptfile" "$tmpfile" "$errfile" "linear create: $_ai_title"
                                         set -l ai_exit $status
 
                                         set -l result (cat $tmpfile)
@@ -637,8 +642,9 @@ mkUserModule {
                                             set -l r_err (mktemp)
                                             printf 'You are refining a Linear issue. Current issue:\n%s\n\nRequested change: %s\n\nReturn ONLY the updated raw JSON object (no markdown fences, no commentary).\nSame schema: {"title": string, "description": string, "priority": int, "labels": string[], "project_hint": string|null, "assign_to_me": boolean}\nKeep fields unchanged unless the instruction implies a change.' "$current_json" "$instruction" > $refine_file
 
+                                            set -l _r_title (string shorten -m 70 -- (string replace -a \n " " -- "$instruction"))
                                             gum spin --spinner dot --title "Refining with AI..." -- \
-                                              sh -c 'opencode run -m "anthropic/claude-haiku-4-5" "$(cat "$1")" > "$2" 2> "$3"' _ "$refine_file" "$r_out" "$r_err"
+                                              sh -c 'd="$HOME/.local/share/lin/scratch"; mkdir -p "$d"; opencode run --dir "$d" --title "$4" -m "anthropic/claude-haiku-4-5" "$(cat "$1")" > "$2" 2> "$3"' _ "$refine_file" "$r_out" "$r_err" "linear refine: $_r_title"
                                             set -l r_exit $status
 
                                             set -l r_result (cat $r_out)

--- a/modules/dev/opencode/scripts/oc-search.sh
+++ b/modules/dev/opencode/scripts/oc-search.sh
@@ -91,6 +91,8 @@ build_list() {
 
   # Subagent sessions (parent_id NOT NULL) are 64% of all rows and are never
   # something you resume by hand, so they are excluded outright.
+  # project_id 'global' is opencode's bucket for runs outside a repo, which is
+  # where headless one-shots (lin ai) are parked on purpose. Also never resumed.
   local rows
   rows=$(sqlite3 -separator "$TAB" "$DB" "
     SELECT s.id,
@@ -99,7 +101,8 @@ build_list() {
            replace(s.directory, '$HOME', '~'),
            s.title
     FROM session s
-    WHERE s.parent_id IS NULL AND s.time_archived IS NULL AND $pred $grep_pred
+    WHERE s.parent_id IS NULL AND s.time_archived IS NULL
+      AND s.project_id <> 'global' AND $pred $grep_pred
     ORDER BY s.time_updated DESC" 2>/dev/null) || true
   [ -z "$rows" ] && return 0
 


### PR DESCRIPTION
`wtlc ai` (via `lin ai`) and lazygit's `<c-a>` / `H` spawn headless `opencode run` sessions. They showed up in the session picker of whatever repo they ran in, all named `New session - <timestamp>` — 23 of them so far.

## Fix

The picker is scoped by `project_id`, so the only way to hide a session is to make it belong to a different project.

- **`lin ai` runs in an empty non-repo dir** (`~/.local/share/lin/scratch`), which lands its sessions in opencode's `global` project. The prompt is self-contained, so no repo context is lost.
- **`oc-search.sh` skips `global`**, so `prefix+n` stays clean too.
- **All four headless runs pass `--title`** — `linear create: <task>`, `linear refine: <instruction>`, `lazygit commit`, `lazygit: <prompt>` — so they're readable if you ever need them.

## What doesn't work

**Archiving.** `time_archived` looks like the obvious answer, but `listByProject` has no archived clause — only the global `/experimental/session` route does. Confirmed against the pinned build (anomalyco v1.18.10) by PATCHing a real session archived on a live server: it still came back in the list.

**lazygit can't be hidden.** Both its commands need the repo cwd to see staged changes, so they can't be parked in a scratch dir. The title is the only fix available there.

**Historical sessions can't be moved.** `project_id` is replayed from the session-created event, so a direct DB update gets reverted by the projector the next time a server starts in that repo. They age out of the picker on their own (30-day window).

## Verification

- `sh -c` line runs standalone, exits 0, stdout unchanged (jq parsing of the model's JSON still works)
- new session confirmed to land in `project_id = global`
- `--title` confirmed to stick (not overwritten by the title agent)
- `statix` / `nixfmt` / `shellcheck` / `fish -n` clean
