### PR TITLE
fix(tmux): stop passing #{session_id} through run-shell

### DIFF
--- a/modules/cli/tmux/new-window.test.sh
+++ b/modules/cli/tmux/new-window.test.sh
@@ -28,6 +28,16 @@ PROG=$(awk '
 # Undo Nix's ''${...} escaping so the body is runnable bash.
 PROG=${PROG//\'\'\$\{/\$\{}
 
+# run-shell expands #{...} into the command string before /bin/sh parses it, so
+# #{session_id} arrives as "01" for session $101 ($1 unset, then "01") and every
+# tmux call targets a session that does not exist. Silent for ids $0-$9 (empty
+# $N, so the script's own default kicked in), fatal from $10 on.
+if grep -n 'run-shell.*#{session_id}' "$SRC"; then
+  echo "FAIL: #{session_id} interpolated into a run-shell command (lines above)"
+  exit 1
+fi
+echo "ok   no #{session_id} passed through run-shell"
+
 command -v fish >/dev/null || {
   echo "SKIP: fish not on PATH (the filter matches on pane_current_command)"
   exit 0
@@ -51,18 +61,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Shim every `tmux` call in the body onto the private socket, and stub the
-# git-root helper (resolution is its own concern, not this script's).
+# Shim every `tmux` call in the body onto the private socket, and stub git
+# (root resolution is its own concern, not this script's).
 cat >"$TMP/bin/tmux" <<EOF
 #!/bin/sh
 exec "$REAL_TMUX" -S "$SOCK" "\$@"
 EOF
-cat >"$TMP/bin/tmux-git-root-path" <<'EOF'
+cat >"$TMP/bin/git" <<'EOF'
 #!/bin/sh
-echo "${1:-.}"
+echo "$2"
 EOF
-chmod +x "$TMP/bin/tmux" "$TMP/bin/tmux-git-root-path"
+chmod +x "$TMP/bin/tmux" "$TMP/bin/git"
 export PATH="$TMP/bin:$PATH"
+# Running this from inside tmux would otherwise leak a pane id from the real
+# server, which resolves to nothing on the private socket.
+unset TMUX_PANE
 
 # fish explicitly for window 1 (default-command only applies to windows created
 # after it is set) and as default-command for the ones the body creates.
@@ -75,6 +88,10 @@ for _ in $(seq 30); do
 done
 
 count() { tmux list-windows -t t -F '#{window_id}' | wc -l | tr -d ' '; }
+# Read the session's own state. `display-message -t t` resolves through the
+# most-recently-used client instead, and on a detached server that reports the
+# wrong window about a third of the time.
+active() { tmux list-windows -t t -F "$1" -f '#{window_active}'; }
 # eval runs in the function's scope, so the body sees $1/$2 as its own args.
 run() { (cd "$PROJ" && eval "$PROG"); }
 
@@ -96,12 +113,11 @@ check "idle window at same root is reused, not duplicated" 1 "$(count)"
 # 2. A window running something is not idle — but the idle one is still found
 #    from it, rather than a third window being created.
 tmux new-window -t t: -c "$PROJ" 'sleep 60'
-busy=$(tmux display-message -p -t t '#{window_id}')
+busy=$(active '#{window_id}')
 run "$PROJ" t >/dev/null
 check "busy window does not block reuse" 2 "$(count)"
-check "reuse selects the idle window, not the busy one" \
-  "$(tmux list-windows -t t -F '#{window_id}' | head -1)" \
-  "$(tmux display-message -p -t t '#{window_id}')"
+idle_win=$(tmux list-windows -t t -F '#{window_id}' | head -1)
+check "reuse selects the idle window, not the busy one" "$idle_win" "$(active '#{window_id}')"
 
 # 3. A different root has no idle window, so one is created.
 tmux select-window -t "$busy"
@@ -109,7 +125,17 @@ run "$OTHER" t >/dev/null
 check "different root creates a new window" 3 "$(count)"
 
 # 4. The new window is at the requested root.
-check "new window opens at the requested root" "$OTHER" \
-  "$(tmux display-message -p -t t '#{pane_current_path}')"
+check "new window opens at the requested root" "$OTHER" "$(active '#{pane_current_path}')"
+
+# 5. The keybind passes no args, so both defaults must resolve from TMUX_PANE.
+#    The active window is the $OTHER one, so pointing TMUX_PANE at the busy
+#    $PROJ window and landing on the idle $PROJ window proves the root came
+#    from the invoking pane and not from whatever happened to be active.
+TMUX_PANE=$(tmux list-panes -t "$busy" -F '#{pane_id}' | head -1)
+export TMUX_PANE
+(cd / && eval "$PROG") >/dev/null || echo "FAIL no-arg defaults: exited $?"
+check "no-arg run resolves root and session from TMUX_PANE" 3 "$(count)"
+check "no-arg run reuses the invoking pane's idle window" "$idle_win" "$(active '#{window_id}')"
+unset TMUX_PANE
 
 exit "$fail"

--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -36,25 +36,46 @@ let
     name = "tmux-new-window";
     runtimeInputs = [
       pkgs.tmux
-      tmux-git-root-path
+      pkgs.git
     ];
     text = ''
-      root=$(tmux-git-root-path "''${1:-.}")
+      # This runs on every prefix+c, so it is written to spawn as few processes
+      # as it can: one tmux round trip for everything the branch below needs,
+      # then git, then the action. Do not reach for tmux-git-root-path here —
+      # the extra wrapper process costs more than the line it saves.
+      #
+      # The keybind passes no args (they exist for the test harness): run-shell
+      # expands #{...} into the command string before /bin/sh parses it, so a
+      # session_id like $101 would arrive as "01". Formats read from in here are
+      # safe — run-shell never sees this file. Target them explicitly, since a
+      # bare target resolves by most-recently-used session rather than by the
+      # pane that invoked us. run-shell exports TMUX_PANE.
+      pane=()
+      if [ -n "''${TMUX_PANE:-}" ]; then pane=(-t "$TMUX_PANE"); fi
+      # Path last: it is the only one of the three that can contain a space.
+      info=$(tmux display-message -p "''${pane[@]}" '#{session_id} #{window_id} #{pane_current_path}')
+      rest=''${info#* }
+      here="''${1:-''${rest#* }}"
+      session="''${2:-''${info%% *}}"
+      win=''${rest%% *}
+
+      root=$(git -C "$here" rev-parse --show-toplevel 2>/dev/null || echo "$here")
       # pane_current_path is always the physical path, and macOS symlinks /tmp
       # and /var (plus any symlinked checkout), so compare like with like —
       # otherwise the match silently never fires and this degrades back into
       # plain new-window with no visible symptom.
       root=$(cd "$root" 2>/dev/null && pwd -P || echo "$root")
-      session="''${2:-$(tmux display-message -p '#{session_id}')}"
 
       # fish is default-command below, so an idle pane reports exactly "fish".
       # Nested #{&&:} because tmux formats have no n-ary and.
       filter="#{&&:#{==:#{window_panes},1},#{&&:#{==:#{pane_current_command},fish},#{==:#{pane_current_path},$root}}}"
-      idle=$(tmux list-windows -t "$session" -F '#{window_id}' -f "$filter" 2>/dev/null | head -1)
+      # read takes the first line without forking head.
+      idle=""
+      read -r idle < <(tmux list-windows -t "$session" -F '#{window_id}' -f "$filter" 2>/dev/null) || true
 
       if [ -z "$idle" ]; then
         tmux new-window -t "$session:" -c "$root"
-      elif [ "$idle" = "$(tmux display-message -p -t "$session" '#{window_id}' 2>/dev/null)" ]; then
+      elif [ "$idle" = "$win" ]; then
         # Selecting the window you are already on is a silent no-op, which
         # reads as a dead keybind. Say so, and advertise the escape hatch.
         tmux display-message "already on an empty window — prefix+C forces a new one"
@@ -251,8 +272,11 @@ mkUserModule {
           # prefix+c reuses an idle window at that root if one exists (see
           # tmux-new-window); prefix+C always creates, mirroring the s/S split.
           # C was tmux's customize-mode, still reachable via prefix+: .
-          bind-key c run-shell '${tmux-new-window}/bin/tmux-new-window "#{pane_current_path}" "#{session_id}"'
-          bind-key C run-shell 'tmux new-window -t "#{session_id}:" -c "$(${tmux-git-root-path}/bin/tmux-git-root-path "#{pane_current_path}")"'
+          # Neither passes #{session_id}: run-shell expands formats into the
+          # command string before /bin/sh parses it, so $101 becomes "01".
+          # run-shell exports TMUX_PANE, so an omitted target is the right one.
+          bind-key c run-shell '${tmux-new-window}/bin/tmux-new-window'
+          bind-key C run-shell 'tmux new-window -c "$(${tmux-git-root-path}/bin/tmux-git-root-path "#{pane_current_path}")"'
           bind-key '"' split-window -c "#{pane_current_path}"
           bind-key % split-window -h -c "#{pane_current_path}"
 


### PR DESCRIPTION
prefix+c has been dying with:

```
'…/tmux-new-window "…/monobloco.worktrees/mo-code-422" "$101"' returned 1
```

## Cause

`run-shell` expands `#{...}` into the command string **before** `/bin/sh` parses it. `#{session_id}` became the literal `$101`, which sh then read as `$1` (unset) followed by `01`:

```
$ sh -c 'echo "$101"'
01
```

So the script received `01`, `tmux list-windows -t 01` failed, and `errexit` killed it.

It only looked fine until now by accident — for sessions `$0`–`$9` the argument expanded to the *empty* string, which fell through to the script's own default. The tenth session made it fatal.

## Fix

- `bind-key c` passes no arguments; the script asks tmux itself, where formats are safe because run-shell never sees the file.
- Targets are explicit via `TMUX_PANE` — a bare tmux target resolves by most-recently-used session, not by the pane that invoked the binding.
- `bind-key C` had the same latent bug in its `-t` and loses it too.

## Same trip, fewer processes

Measured on a 6-window session, 15 runs, median: **34.1 ms before → 36.1 ms after** (within noise; cost is process spawns, ~5 ms per tmux client, ~6 ms for git). Three spawns removed along the way:

- one `display-message` for session, window and path together instead of two calls
- `git` directly instead of through the `tmux-git-root-path` wrapper (a whole extra bash)
- `read` builtin instead of a piped `head`

The remaining round trip could be dropped by passing `#{session_name}` and friends through the keybind, saving ~5 ms — that is the exact mechanism that broke here, so no.

## Tests

`new-window.test.sh` goes 6 → 8 checks:

- a guard that fails if `#{session_id}` ever appears in a `run-shell` command again
- a no-arg run proving both defaults resolve from `TMUX_PANE` alone

Separately, the suite stopped reading the active window through `display-message -t <session>`, which resolves via the most-recently-used client and reported the wrong window about a third of the time on a detached server — the old assertions were silently flaky. Now reads `#{window_active}`; 8/8 stable across repeated runs.
