### PR TITLE
feat(tmux): snooze PRs until they get updates

### DIFF
--- a/modules/cli/tmux/pr.nix
+++ b/modules/cli/tmux/pr.nix
@@ -11,18 +11,42 @@
 # a direct-only count (`user-review-requested:@me`) reads 0 or 1 forever and
 # would hide the actual queue.
 #
-# That makes the raw number large, and the ignore list is what makes it
-# tractable: `x` appends the PR url to a plain-text file that both views and
-# the status count filter against, `u` clears it. Permanent by design — no
-# expiry, no "until new activity". A dismissed PR stays dismissed.
+# That makes the raw number large, and the snooze list is what makes it
+# tractable: `x` records the PR url together with its current updatedAt, and
+# both views and the status count hide it for as long as that timestamp still
+# matches. Anything that moves the PR — a new commit, a comment, draft→ready —
+# bumps updatedAt, so a snoozed PR resurfaces by itself the moment it is worth
+# looking at again.
+#
+# Hiding without recall is just a slower way to lose a PR, so `s` folds the
+# snoozed ones back in, dimmed, and `x` on one of those wakes it up. `u` is the
+# nuclear option and clears the list outright.
 { pkgs }:
 let
   # ── shared paths ────────────────────────────────────────────────────────
   # Cache is disposable (TMPDIR, like the session picker's PR cache); the
-  # ignore list is not, so it lives in XDG state and survives reboots.
+  # snooze list is not, so it lives in XDG state and survives reboots.
   cache = ''"''${TMPDIR:-/tmp}/tmux-pr.json"'';
   ignoreFile = ''"$HOME/.local/state/tmux-pr/ignored"'';
   viewFile = ''"''${TMPDIR:-/tmp}/tmux-pr.view"'';
+  showFile = ''"''${TMPDIR:-/tmp}/tmux-pr.show"'';
+
+  # Every snooze-aware query shares this prelude. The file is one
+  # "<url>\t<updatedAt>" per line; from_entries makes the last line for a url
+  # win, which is what re-snoozing an updated PR should do.
+  #
+  # A line with no tab — the old format — carries an empty timestamp and never
+  # expires, so PRs dismissed under the previous scheme stay dismissed instead
+  # of all flooding back on the first rebuild.
+  #
+  # ponytail: the file only grows, and `u` is the compaction strategy. A few
+  # hundred stale lines cost nothing to parse; prune them if it ever shows up
+  # in the 5s widget tick.
+  jqIgnore = ''
+    ($ign | split("\n") | map(select(length > 0) | split("\t") | { key: .[0], value: (.[1] // "") }) | from_entries) as $ign
+    | def snoozed: $ign[.url] as $at | $at != null and ($at == "" or $at == .updated);
+      def live: map(select(snoozed | not));
+  '';
 
   # One request for both lists. Measured cost: 1 point of the 5000/hr GraphQL
   # budget, so even a 60s poll is ~1.2% of it. `gh search prs` cannot do this —
@@ -142,17 +166,19 @@ let
 
       [ -f "$CACHE" ] || exit 0
 
+      # The count never counts snoozed PRs, whatever the popup happens to be
+      # showing: `s` is a way to look at them, not a way to wake them.
       n=$(jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" '
-        ($ign | split("\n") | map(select(length > 0))) as $ign
-        | .review | map(select(.url as $u | $ign | index($u) | not)) | length
+        ${jqIgnore}
+        .review | live | length
       ' "$CACHE" 2>/dev/null) || exit 0
 
       case "''${n:-}" in "" | *[!0-9]*) exit 0 ;; esac
 
       # Silent at zero, like the disk widget: an empty queue is not news, and a
-      # segment that is always on screen is a segment you stop seeing. Ignoring
+      # segment that is always on screen is a segment you stop seeing. Snoozing
       # the last PR therefore clears the slot entirely, which is the point of
-      # ignoring it.
+      # snoozing it.
       [ "$n" -gt 0 ] || exit 0
 
       # Black rather than a threshold colour: this is a thing you scan for on
@@ -168,26 +194,30 @@ let
       fzf
       jq
       gh
+      gawk
       coreutils
     ];
     text = ''
       CACHE=${cache}
       IGNORE=${ignoreFile}
       VIEW=${viewFile}
+      SHOW=${showFile}
 
       self="$0"
       view=$(cat "$VIEW" 2>/dev/null) || true
       case "$view" in review | mine) ;; *) view=review ;; esac
+      show=$(cat "$SHOW" 2>/dev/null) || true
+      case "$show" in 1) ;; *) show="" ;; esac
 
       # ── row rendering ─────────────────────────────────────────────────────
       # Emits "<url>\t<display>"; fzf shows field 2 and the binds consume {1}.
       # @tsv escapes tab/newline/backslash only, so the ANSI escapes below
       # survive it intact.
       render() {
-        jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" --arg view "$1" '
-          ($ign | split("\n") | map(select(length > 0))) as $ign
+        jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" --arg view "$1" --arg show "$2" '
+          ${jqIgnore}
 
-          | def dim: "\u001b[2m"  + . + "\u001b[0m";
+            def dim: "\u001b[2m"  + . + "\u001b[0m";
             def red: "\u001b[31m" + . + "\u001b[0m";
             def grn: "\u001b[32m" + . + "\u001b[0m";
             def yel: "\u001b[33m" + . + "\u001b[0m";
@@ -212,50 +242,66 @@ let
               else                                       "" end;
 
           .[$view]
-          | map(select(.url as $u | $ign | index($u) | not))
+          | (if $show == "1" then . else live end)
           | sort_by(.updated) | reverse
           | .[]
           | [ .url,
-              ( ((.repo | split("/") | last) + "#" + (.number | tostring) | dim)
-                + "  " + (if .draft then ("draft " | dim) else "" end)
-                + .title
-                + "  "
-                + (if $view == "mine"
-                   then ([ci, decision] | map(select(length > 0)) | join(""))
-                   else ("@" + .author | dim) end)
-                + "  " + (age | dim) )
+              ( ( ((.repo | split("/") | last) + "#" + (.number | tostring) | dim)
+                  + "  " + (if .draft then ("draft " | dim) else "" end)
+                  + .title
+                  + "  "
+                  + (if $view == "mine"
+                     then ([ci, decision] | map(select(length > 0)) | join(""))
+                     else ("@" + .author | dim) end)
+                  + "  " + (age | dim) ) as $row
+
+                # A snoozed row goes fully dim. Wrapping the finished row would
+                # not work — its own inner resets end the dim a third of the way
+                # in — so strip every SGR code first and re-apply one. Losing
+                # the CI colours is the point: a row you already dropped should
+                # read as background noise.
+                | if snoozed
+                  then ($row | gsub("\u001b\\[[0-9;]*m"; "") | dim)
+                  else $row end )
             ]
           | @tsv
         ' "$CACHE" 2>/dev/null
       }
 
       # fzf's header is a plain string, so mark the active view rather than
-      # rebuilding a widget: "[review 74] · mine 1".
+      # rebuilding a widget: "[review 74] · mine 1 · 3 snoozed".
       header_line() {
-        local v="$1" counts r m
+        local v="$1" s="$2" counts r m z tail=""
         local parts=()
-        counts=$(jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" '
-          ($ign | split("\n") | map(select(length > 0))) as $ign
-          | def live: map(select(.url as $u | $ign | index($u) | not)) | length;
-            [ (.review | live), (.mine | live) ] | @tsv
+        counts=$(jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" --arg view "$v" '
+          ${jqIgnore}
+          [ (.review | live | length),
+            (.mine   | live | length),
+            (.[$view] | map(select(snoozed)) | length) ] | @tsv
         ' "$CACHE" 2>/dev/null) || counts=""
-        IFS=$'\t' read -r r m <<<"$counts"
+        IFS=$'\t' read -r r m z <<<"$counts"
         for pair in "review:''${r:-0}" "mine:''${m:-0}"; do
           local nm="''${pair%%:*}" n="''${pair##*:}"
           if [ "$nm" = "$v" ]; then parts+=("[$nm $n]"); else parts+=("$nm $n"); fi
         done
-        printf '%s · %s\n' "''${parts[@]}"
-        printf 'enter open · x ignore · u unignore all · tab view · r refresh\n'
+        # The snoozed tally only earns header space when it is non-zero, and it
+        # has to say whether those rows are on screen: a dimmed row and a hidden
+        # row are indistinguishable if you cannot tell which mode you are in.
+        if [ "''${z:-0}" -gt 0 ]; then
+          if [ -n "$s" ]; then tail=" · $z snoozed shown"; else tail=" · $z snoozed"; fi
+        fi
+        printf '%s · %s%s\n' "''${parts[@]}" "$tail"
+        printf 'enter open · x snooze · s show · u clear · / search · tab view · r refresh\n'
       }
 
       # ── subcommands driven by fzf binds ──────────────────────────────────
       case "''${1:-}" in
         --list)
-          render "$view"
+          render "$view" "$show"
           exit 0
           ;;
         --header)
-          header_line "$view"
+          header_line "$view" "$show"
           exit 0
           ;;
         --cycle)
@@ -270,10 +316,38 @@ let
           printf 'reload(%s --list)+transform-header(%s --header)+first' "$self" "$self"
           exit 0
           ;;
-        --ignore)
+        --show-toggle)
+          if [ -n "$show" ]; then
+            : >"$SHOW" 2>/dev/null || true
+          else
+            printf '1' >"$SHOW" 2>/dev/null || true
+          fi
+          exit 0
+          ;;
+        --snooze)
           [ -n "''${2:-}" ] || exit 0
           mkdir -p "$(dirname "$IGNORE")" 2>/dev/null || true
-          printf '%s\n' "$2" >>"$IGNORE"
+
+          # Snooze against the timestamp you are looking at, which is whatever
+          # the cache last saw.
+          at=$(jq -r --arg u "$2" '
+            ([.review[], .mine[]] | map(select(.url == $u)) | .[0].updated) // ""
+          ' "$CACHE" 2>/dev/null) || at=""
+
+          # One rule covers both directions: drop every line for this url, then
+          # put one back unless the PR was already hidden. That makes `x` a
+          # toggle on a dimmed row, while a row that resurfaced on its own is
+          # re-snoozed at its new timestamp instead of being woken up.
+          # shellcheck disable=SC2016  # awk field refs, not shell positionals
+          hidden=$(awk -F'\t' -v u="$2" -v at="$at" '$1 == u && ($2 == "" || $2 == at)' "$IGNORE" 2>/dev/null)
+          tmp=$(mktemp) || exit 0
+          # shellcheck disable=SC2016
+          if awk -F'\t' -v u="$2" '$1 != u' "$IGNORE" >"$tmp" 2>/dev/null; then
+            mv "$tmp" "$IGNORE"
+          fi
+          rm -f "$tmp"
+
+          [ -n "$hidden" ] || printf '%s\t%s\n' "$2" "$at" >>"$IGNORE"
           exit 0
           ;;
         --unignore-all)
@@ -290,20 +364,22 @@ let
           ;;
       esac
 
-      # Always open on the review queue: that is the view the status count
-      # refers to, and prefix+P is a reflex. Tabbing to your own PRs and
-      # closing should not leave them in front of the next reflex. The view
-      # file only carries state between fzf's transform binds, not between
-      # opens.
+      # Always open on the review queue with snoozed rows folded away: that is
+      # what the status count refers to, and prefix+P is a reflex. Tabbing to
+      # your own PRs, or peeking at the snoozed pile, should not leave either in
+      # front of the next reflex. Both state files only carry state between
+      # fzf's transform binds, not between opens.
       view=review
       printf '%s' "$view" >"$VIEW" 2>/dev/null || true
+      show=""
+      : >"$SHOW" 2>/dev/null || true
 
       # Cold cache: fetch synchronously so the first open shows data instead of
       # an empty box. Every later open reads whatever the status widget last
       # refreshed, so this branch is effectively first-run only.
       [ -f "$CACHE" ] || ${tmux-pr-refresh}/bin/tmux-pr-refresh
 
-      list=$(render "$view")
+      list=$(render "$view" "$show")
       if [ -z "$list" ]; then
         list=$'\t'"$(printf '\033[2mnothing here\033[0m')"
       fi
@@ -315,26 +391,51 @@ let
       # shellcheck disable=SC2016  # {1} is fzf's placeholder, not a shell var
       b_open='execute-silent('"$self"' --open {1})'
       # shellcheck disable=SC2016
-      b_ignore='execute-silent('"$self"' --ignore {1})+'"$redraw"
+      b_snooze='execute-silent('"$self"' --snooze {1})+'"$redraw"
+      b_show='execute-silent('"$self"' --show-toggle)+'"$redraw"
       b_unignore='execute-silent('"$self"' --unignore-all)+'"$redraw"
       b_refresh='execute-silent(${tmux-pr-refresh}/bin/tmux-pr-refresh)+'"$redraw"
+
+      # Menu mode by default (--disabled), `/` for search — same two modes as
+      # the session picker. A bare printable bind wins over typing, so with
+      # search live from the start every action key is also a letter you cannot
+      # type: "parser" arrived as "pae" while the two r's each fired a
+      # synchronous gh round trip and the s toggled the snoozed rows. Unbinding
+      # them for the duration of a query is what makes the search box a search
+      # box.
+      #
+      # change:clear-query is the other half. --disabled only stops the query
+      # from filtering, it still collects every unbound letter, so menu mode
+      # would quietly build up a "pae" in the prompt that looks like a search
+      # doing nothing. Wiping it on change keeps the prompt honest; the bind has
+      # to come off in search mode or it would eat the query as you type it.
+      b_search='unbind(change)+unbind(x)+unbind(s)+unbind(u)+unbind(r)+unbind(/)+clear-query+change-prompt(/ )+enable-search'
+      # Back to menu mode: reload repopulates the full list, since disable-search
+      # on its own freezes whatever subset the last query left behind.
+      b_esc_back='clear-query+disable-search+change-prompt(❯ )+rebind(change)+rebind(x)+rebind(s)+rebind(u)+rebind(r)+rebind(/)+'"$redraw"
+      # shellcheck disable=SC2016  # $FZF_PROMPT is fzf's, not bash's
+      b_esc='transform~[ "$FZF_PROMPT" = "/ " ] && echo "'"$b_esc_back"'" || echo abort~'
 
       printf '%s\n' "$list" | fzf \
         --ansi --no-sort --layout=reverse --cycle \
         --delimiter='\t' --with-nth=2 \
+        --disabled \
         --prompt='❯ ' \
         --info=inline-right \
         --pointer='▶' \
         --gutter=' ' \
         --color='pointer:green,prompt:green,info:dim,header:dim' \
-        --header="$(header_line "$view")" \
+        --header="$(header_line "$view" "$show")" \
         --bind "enter:$b_open" \
-        --bind "x:$b_ignore" \
+        --bind "x:$b_snooze" \
+        --bind "s:$b_show" \
         --bind "u:$b_unignore" \
         --bind "r:$b_refresh" \
+        --bind "/:$b_search" \
+        --bind 'change:clear-query' \
         --bind "tab:transform:$self --cycle" \
         --bind 'ctrl-c:abort' \
-        --bind 'esc:abort'
+        --bind "esc:$b_esc"
     '';
   };
 in


### PR DESCRIPTION
Follow-up to #600. Some PRs land in the review queue before they are actually ready, and the only tool for that was `x` — a permanent dismissal. Dropping a PR forever is the wrong default when the thing that should bring it back is the author pushing a commit.

## Snooze until the PR moves

`x` now records the url **plus the `updatedAt` it had when you dropped it**:

```
https://github.com/org/repo/pull/42	2026-08-09T12:00:00Z
```

The PR stays hidden only while that timestamp holds. A new commit, a comment, or draft→ready bumps `updatedAt`, and the PR walks back into the list and the status count on its own. No expiry to tune, no second API field to fetch — `updatedAt` was already in the cache.

Lines with no tab are the old format and never expire, so anything already dismissed stays dismissed instead of flooding back on the first rebuild.

## `s` shows the snoozed ones, dimmed

Hiding without recall is just a slower way to lose a PR. `s` folds them back into the list, fully dimmed, and `x` on one of those wakes it up — previously the only way back was `u`, which nukes everything.

```
[review 2] · mine 0 · 1 snoozed shown
enter open · x snooze · s show · u clear · / search · tab view · r refresh
  api#3  Bump deps  @carol  6h
  web#2  Add retry to uploader  @bob  1d
  web#1  draft WIP: refactor the scheduler  @alice  9d      <- dimmed
```

Dimming strips every SGR code from the finished row and re-applies one, because wrapping the row as-is ends the dim at its first inner reset. Losing the CI colours is the point: a row you already dropped should read as background noise. The status count still excludes snoozed PRs regardless of this toggle — `s` is a way to look, not a way to wake.

## Fixes: fzf action keys were eating the search query

Not new to this PR, but adding `s` made it untenable. `x`, `u` and `r` were already bound as bare printable keys, and **an fzf key bind beats typing**. Reproduced against `main`'s build in a real tmux pane — typing `parser`:

```
❯ pae                                                    3/3
```

The two `r`s each fired `tmux-pr-refresh`, i.e. a **synchronous `gh api graphql` round trip**, which is the stall you feel a few characters into a query. The `s` toggled the snoozed rows. And any query containing an `x` — `fix`, `index`, `max` — silently snoozed whatever row was highlighted.

The popup now runs the same two modes as `session-picker.nix`: menu by default (`--disabled`), `/` to search, `esc` back to the full list. `change:clear-query` covers the other half — `--disabled` only stops the query from *filtering*, it still collects every unbound letter, so menu mode used to accumulate a phantom `pae` in the prompt that looked like a broken search.

Deliberately left alone: bare-letter binds are a convention question across every fzf popup in this repo, not just this one, and they are not consistent today. Worth one pass over all of them rather than diverging here.

## Verification

- 9-scenario end-to-end suite against the built binaries: snooze hides, resurfaces on `updatedAt` change, re-snooze re-arms at the new timestamp, `x`-on-dimmed wakes, legacy tab-less lines persist, `u` clears, `mine` view unaffected.
- Input modes driven through a real tmux pane: menu mode fires nothing on unbound letters and leaves the prompt clean; `/` types a full query and filters; `esc` restores the full list; `x` writes url + timestamp.
- `nixfmt`, `statix`, and `shellcheck` (via `writeShellApplication`) clean.
