### PR TITLE
fix(worktree): stop wtrm's cleanup output hijacking another session

### DIFF
--- a/modules/cli/worktree/worktree.nix
+++ b/modules/cli/worktree/worktree.nix
@@ -323,9 +323,12 @@ mkUserModule {
               end
             end
 
-            # Switch to parent, then schedule cleanup in background
+            # Switch to parent, then schedule cleanup in background.
+            # Silenced: run-shell displays stdout (and a failing exit status) in
+            # view mode on whatever client is attached — git's "Deleted branch
+            # X" would take over an unrelated session seconds later.
             command tmux switch-client -t "=$parent_session"
-            command tmux run-shell -b "$cleanup"
+            command tmux run-shell -b "{ $cleanup; } >/dev/null || true"
           else
             # Regular remove (from a different session)
             if set -q TMUX


### PR DESCRIPTION
## Problem

Self-removing a worktree (`wtrm` with no args from inside its session) can't
clean up synchronously — it has to switch the client away first, then run
`kill-session` + `git worktree remove` + `git branch -d` via
`tmux run-shell -b`.

`run-shell` displays the job's stdout in view mode on whatever client is
attached when the job finishes. So git's `Deleted branch X (was abc).` showed
up seconds later, full screen, in whatever unrelated session you'd moved on to.

A not-fully-merged branch made it worse: `git branch -d` exits nonzero, and
run-shell displays the exit status too.

## Fix

```diff
-command tmux run-shell -b "$cleanup"
+command tmux run-shell -b "{ $cleanup; } >/dev/null || true"
```

Nothing is lost: `run-shell` ignores stderr unless given `-E`, so real failures
were never surfaced there anyway. The uncommitted-changes check still runs
*before* the switch, where its error can actually reach you.

The immediate `Removed worktree 'X'` echo on the non-self-remove path is
untouched — that one prints inline, in your own terminal, at the moment you
asked for it.