### PR TITLE
fix(worktree): make wtrm idempotent

### DIFF
--- a/modules/cli/worktree/worktree.nix
+++ b/modules/cli/worktree/worktree.nix
@@ -259,11 +259,30 @@ mkUserModule {
             or return 1
           end
 
+          # Guard: $wt_path gets rm -rf'd below, so no traversal in $name
+          if string match -qr '(^\.|/)' -- "$name"
+            echo "wtrm: invalid worktree name '$name'"
+            return 1
+          end
+
           set wt_path "$wt_base/$repo_name.worktrees/$name"
 
-          if not test -d "$wt_path"
-            echo "wtrm: no worktree found for '$name'"
-            return 1
+          # Resolve the branch so a half-deleted worktree still cleans up fully:
+          # from the worktree itself, else from git's (possibly stale)
+          # registration, else the name wt would have given it.
+          set -l branch (git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+          if test -z "$branch" -o "$branch" = "HEAD"
+            set branch (git worktree list --porcelain | awk -v p="$wt_path" '$1=="worktree"{m=($2==p)} m&&$1=="branch"{sub("refs/heads/","",$2); print $2; exit}')
+          end
+          test -n "$branch"; or set branch (_wt_prefix)"$name"
+          git show-ref --verify --quiet "refs/heads/$branch"; or set branch ""
+
+          # Already in the desired state: prune any stale registration and stop.
+          # Removing something twice is not an error.
+          if not test -e "$wt_path"; and test -z "$branch"
+            git worktree prune
+            echo "wtrm: '$name' already removed"
+            return 0
           end
 
           # Confirm when name was auto-detected from session
@@ -298,8 +317,6 @@ mkUserModule {
               end
             end
 
-            set -l branch (git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
-
             # Pre-check for uncommitted changes (can't report errors after switching away)
             if test $force -eq 0
               if test -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)"
@@ -308,14 +325,15 @@ mkUserModule {
               end
             end
 
-            # Build cleanup command (POSIX shell, runs server-side via tmux run-shell -b)
+            # Build cleanup command (POSIX shell, runs server-side via tmux
+            # run-shell -b). Every step tolerates already-being-done: --force is
+            # safe here because the pre-check above cleared the worktree, and
+            # rm -rf + prune reconcile a dir git no longer tracks (or vice versa).
             set -l cleanup "tmux kill-session -t '=$current_session'"
-            if test $force -eq 1
-              set cleanup "$cleanup; git -C '$main_root' worktree remove --force '$wt_path'"
-            else
-              set cleanup "$cleanup; git -C '$main_root' worktree remove '$wt_path'"
-            end
-            if test -n "$branch" -a "$branch" != "HEAD"
+            set cleanup "$cleanup; git -C '$main_root' worktree remove --force '$wt_path' 2>/dev/null"
+            set cleanup "$cleanup; rm -rf '$wt_path'"
+            set cleanup "$cleanup; git -C '$main_root' worktree prune"
+            if test -n "$branch"
               if test $force -eq 1
                 set cleanup "$cleanup; git -C '$main_root' branch -D '$branch' 2>/dev/null"
               else
@@ -338,25 +356,32 @@ mkUserModule {
               end
             end
 
-            set -l branch (git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
-
-            if test $force -eq 1
-              git worktree remove --force "$wt_path"
-            else
-              git worktree remove "$wt_path"
+            # Refuse to throw away real work; anything else is fair game
+            if test $force -eq 0; and test -n "$(git -C "$wt_path" status --porcelain 2>/dev/null)"
+              echo "wtrm: worktree has changes — use 'wtrm --force $name' to force"
+              return 1
             end
-            or begin; echo "wtrm: worktree has changes — use 'wtrm --force $name' to force"; return 1; end
 
-            if test -n "$branch" -a "$branch" != "HEAD"
-              if test $force -eq 1
-                git branch -D "$branch" 2>/dev/null
-              else
-                git branch -d "$branch" 2>/dev/null
-              end
-              and echo "Removed worktree '$name' and branch '$branch'"
-              or echo "Removed worktree '$name' (branch '$branch' not fully merged — use 'wtrm --force $name' to force)"
-            else
+            # Don't rm the floor out from under the shell
+            if string match -q "$wt_path*" -- "$PWD"
+              cd "$main_root"
+            end
+
+            # Teardown: each step tolerates already-being-done, so a dir git
+            # forgot (or a registration whose dir vanished) still ends up gone.
+            git worktree remove --force "$wt_path" 2>/dev/null
+            rm -rf "$wt_path"
+            git worktree prune
+
+            if test -z "$branch"
               echo "Removed worktree '$name'"
+            else if test $force -eq 1
+              git branch -D "$branch" 2>/dev/null
+              echo "Removed worktree '$name' and branch '$branch'"
+            else if git branch -d "$branch" 2>/dev/null
+              echo "Removed worktree '$name' and branch '$branch'"
+            else
+              echo "Removed worktree '$name' (branch '$branch' not fully merged — use 'wtrm --force $name' to force)"
             end
           end
         '';


### PR DESCRIPTION
`wtrm` gave up whenever reality and git's bookkeeping disagreed:

- it bailed at `test -d $wt_path` before doing anything, so a registration whose dir had been deleted by hand was unreachable
- `git worktree remove` hard-failed on a dir git no longer tracked, leaving it on disk

`wt`'s picker reads `ls .worktrees/` rather than `git worktree list`, so those leftovers stayed visible while being unremovable. The only way out was `rm -rf`'ing them by hand.

## What changed

Removal is now a teardown where every step tolerates already-being-done:

```fish
git worktree remove --force "$wt_path" 2>/dev/null   # tracked case
rm -rf "$wt_path"                                    # dir git forgot
git worktree prune                                   # registration whose dir vanished
git branch -d/-D "$branch" 2>/dev/null               # already-gone branch
```

Any starting state converges on the same end state, and removing something twice is a no-op that exits 0 instead of erroring.

The branch to delete is now read from git's (possibly stale) registration via `git worktree list --porcelain` when the worktree itself is unreadable — so a half-deleted worktree on an explicitly-named branch cleans up too, not just ones following the `wt` naming convention.

## Behaviour

| case | before | after |
|---|---|---|
| stale dir git never knew about | `no worktree found`, dir stays | `Removed worktree 'ghost'` |
| registered, dir deleted by hand | `no worktree found` | removes branch + prunes |
| remove twice / typo'd name | `no worktree found`, exit 1 | `already removed`, exit 0 |
| untracked files, no `--force` | refused | refused (unchanged) |
| untracked files, `--force` | removed | removed (unchanged) |
| `wtrm ..` | `rm -rf`'d the worktrees dir | `invalid worktree name` |

## Safety

Uncommitted changes still refuse without `--force` — the check moved to `git status --porcelain` so it applies uniformly to both the self-remove and regular paths. Since `$wt_path` is now `rm -rf`'d, names containing `/` or a leading `.` are rejected. If the shell's cwd is inside the worktree, it `cd`s to the main root first.

## Verification

- 9 cases exercised against throwaway repos covering every row above
- self-remove cleanup chain run through `sh` directly, since it executes as POSIX shell via `tmux run-shell -b` — exits 0 on both a real worktree and a ghost dir
- `nix eval` on the built config piped through `fish --no-execute`, confirming Nix string interpolation leaves the embedded `awk` intact
- `statix check .` and `nixfmt --check` clean

## Known limit

If two worktrees are both half-deleted with explicitly-named branches, removing the first prunes the second's registration and loses its branch name; that branch falls back to the `wt` guess and may survive. Narrow enough not to warrant code — `git branch -D` it if it ever comes up.
