### PR TITLE
feat(tmux): tell opencode agents they can use tmux

### DIFF
--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -211,6 +211,28 @@ mkUserModule {
       # Outbound: configure ghostty to auto-attach tmux
       programs.ghostty.settings.command = lib.mkIf userCfg.ghostty.enable "${tmux-attach}/bin/tmux-attach";
 
+      # Outbound integration: agents run in /bin/sh and have no idea they're
+      # inside a tmux server. Tell them the layout and that they can use it.
+      # `xdg.configFile.<name>.text` is `types.lines`, so this concatenates
+      # onto opencode's global AGENTS.md.
+      xdg.configFile."opencode/AGENTS.md".text = lib.mkIf userCfg.opencode.enable ''
+
+        ## I work in tmux
+
+        You are running inside my tmux server and can use it. `tmux
+        display-message -p '#S'` tells you which session you are in; a
+        `parent/branch` name means it is a git worktree on that branch.
+
+        Every session you did not create is mine. Never kill, rename, detach,
+        or send-keys to one.
+
+        Create your own freely — windows, panes, sessions — for dev servers, log
+        tails, anything long-running or interactive that would block your shell.
+        Name every session `agents/<name>`. Always detached:
+        `tmux new-session -d -s agents/<name>` (you are already inside tmux, so
+        an attached `new-session` errors). Kill them when you are done.
+      '';
+
       programs.tmux = {
         enable = true;
         # default-shell is the wrapper tmux uses to run jobs — display-popup


### PR DESCRIPTION
Agents run in `/bin/sh` and have no idea they are inside a tmux server, so they never reach for it when something needs to outlive or block their shell.

Appends a section to opencode's global `AGENTS.md` covering:

- the session layout, and that a `parent/branch` session name means a git worktree on that branch
- "every session you did not create is mine" — one rule instead of a name list, so it stays correct as sessions come and go
- `agents/*` reserved for agent-created sessions
- `new-session` must be `-d`; an attached one errors from inside tmux

Lives in the tmux module rather than the opencode module because tmux owns its outbound integrations, matching how `cli/fish.nix` appends its own section.

Deliberately **not** included: a catalog of the `wt` / `wts` / `wtl` / `lin` / git-alias families. Those are fish functions, so they are not callable from an agent's POSIX shell at all, and the `tmux-*` binaries that *are* on PATH are fzf/popup UIs that would hang a non-interactive shell. Documenting them would create docs that exist only to rot.

## Verification

- `nixfmt` — no changes beyond the added block
- `statix check` — clean
- `nix eval .#darwinConfigurations.vega.config.home-manager.users.fernando.xdg.configFile."opencode/AGENTS.md".text` — section renders with indentation stripped and concatenates correctly alongside the existing ADHD and fish sections