### PR TITLE
perf(worktree): make the wt picker 20x faster with fsmonitor + parallel rows

### DIFF
--- a/modules/cli/worktree/worktree.nix
+++ b/modules/cli/worktree/worktree.nix
@@ -7,21 +7,43 @@ let
   # Rows for the worktree pickers: "name  *  2 days ago", most recent first.
   #
   # Sorted by commit epoch, not by the rendered string ("2 weeks ago" doesn't
-  # collate). Stable, so equal timestamps fall back to the glob's alphabetical
-  # order — both passes below then agree on ordering, which is what keeps the
-  # async swap from reshuffling rows under the cursor.
+  # collate), then by name to break ties. Both keys are explicit because the
+  # rows are produced in parallel and so arrive in nondeterministic order —
+  # the old code leaned on a stable sort preserving the glob's alphabetical
+  # order, which parallelism destroys. Getting this wrong doesn't corrupt
+  # anything, it just reshuffles rows under the cursor when the async pass
+  # swaps in.
   #
   # `*` is the *same* status check wtrm gates --force on, so the marker can
-  # never disagree with what removal will actually do. That check is also the
-  # only slow part — a working-tree scan, ~120ms per worktree, ~4s across a
-  # 38-worktree monorepo, and measurably I/O-bound (parallelising it plateaus
-  # at 1.5x and gets *worse* past -P 8, so don't bother).
+  # never disagree with what removal will actually do. It's also the only slow
+  # part: a working-tree scan, ~150ms per worktree, ~2.5s across a 17-worktree
+  # monorepo.
   #
-  # Hence --fast: identical layout minus the scan, ~300ms for the same 38, so
-  # the picker can open on it immediately and swap in the marks afterwards.
+  # Two things fix that, and the order matters — measured on that monorepo:
+  #
+  #   serial, no fsmonitor          2571ms   (what this used to be)
+  #   parallel alone, -P 16         1474ms   1.7x
+  #   core.fsmonitor alone           757ms   3.4x
+  #   both                           126ms   20x
+  #
+  # Parallelism alone really does plateau at ~1.7x, which is what an earlier
+  # note here concluded before giving up on it. But the thing it was
+  # contending on was the working-tree scan, and core.fsmonitor (set in
+  # modules/dev/git.nix) deletes that scan rather than sharing it out. With
+  # the scan gone there's nothing left to serialise on, so the two compound
+  # instead of overlapping. Don't reintroduce one without the other and
+  # re-measure — either alone looks disappointing.
+  #
+  # --fast stays anyway: identical layout minus the scan, so the picker opens
+  # on it immediately and swaps in the marks afterwards. It's cheap insurance
+  # for repos where fsmonitor isn't running yet (the daemon's first call still
+  # pays a full scan while it warms up).
   wt-rows = pkgs.writeShellApplication {
     name = "wt-rows";
-    runtimeInputs = [ pkgs.git ];
+    runtimeInputs = [
+      pkgs.git
+      pkgs.bash
+    ];
     text = ''
       # usage: wt-rows [--fast] <worktrees-dir>
       fast=""
@@ -33,15 +55,13 @@ let
       wd="''${1:-}"
       [ -d "$wd" ] || exit 0
 
-      for dir in "$wd"/*/; do
-        path="''${dir%/}"
+      # One row. Runs in an xargs child, so everything it needs is exported.
+      row() {
+        path="$1"
         name="''${path##*/}"
-        # An empty dir leaves the glob unmatched, expanding to the pattern
-        if [ "$name" = "*" ]; then continue; fi
 
         # --no-optional-locks: this is a read-only probe, so don't take the
-        # index lock or write the refreshed index back (halves the cost, and
-        # keeps 38 of these from serialising on one .git dir).
+        # index lock or write the refreshed index back.
         mark=" "
         if [ -z "$fast" ] &&
           [ -n "$(git --no-optional-locks -C "$path" status --porcelain 2>/dev/null || true)" ]; then
@@ -54,8 +74,22 @@ let
         stamp="''${meta%% *}"
         [ -n "$stamp" ] || stamp=0
 
+        # Single write, ~55 bytes. Under PIPE_BUF (512 on darwin) a pipe write
+        # is atomic, so parallel children can't interleave halves of a row.
         printf '%s\t%-24s %s  %s\n' "$stamp" "$name" "$mark" "''${meta#* }"
-      done | sort -s -rn | cut -f2-
+      }
+      export -f row
+      export fast
+
+      for dir in "$wd"/*/; do
+        path="''${dir%/}"
+        # An empty dir leaves the glob unmatched, expanding to the pattern
+        if [ "''${path##*/}" = "*" ]; then continue; fi
+        printf '%s\n' "$path"
+      done \
+        | xargs -P "$(sysctl -n hw.ncpu 2>/dev/null || echo 8)" -I{} bash -c 'row "$@"' _ {} \
+        | sort -t"$(printf '\t')" -k1,1rn -k2,2 \
+        | cut -f2-
     '';
   };
 in

--- a/modules/cli/worktree/worktree.nix
+++ b/modules/cli/worktree/worktree.nix
@@ -186,7 +186,6 @@ mkUserModule {
           # Create worktree if dir doesn't exist
           set -l is_new 0
           if not test -d "$wt_path"
-            git fetch origin 2>/dev/null
             set base_branch (git rev-parse --abbrev-ref HEAD 2>/dev/null)
             if test -z "$base_branch" -o "$base_branch" = "HEAD"
               echo "wt: detached HEAD — checkout a branch first"
@@ -198,13 +197,25 @@ mkUserModule {
             # explicit branch arg is used verbatim.
             test -z "$branch"; and set branch (_wt_prefix)"$name"
 
-            # Use existing branch (local, then remote), else create it from current
+            # Use existing branch (local, then remote), else create it from current.
+            #
+            # The local check goes first so it can answer without the network.
+            # `git fetch origin` costs ~2.7s against a big repo and the only
+            # thing it feeds is the refs/remotes lookup below — so it's pure
+            # latency once a local branch has already matched, which is every
+            # time you re-create a worktree you deleted.
             if git show-ref --verify --quiet "refs/heads/$branch"
               git worktree add "$wt_path" "$branch"
-            else if git show-ref --verify --quiet "refs/remotes/origin/$branch"
-              git worktree add --track -b "$branch" "$wt_path" "origin/$branch"
             else
-              git worktree add -b "$branch" "$wt_path" "$base_branch"
+              # No local branch. Now the remote's answer actually matters:
+              # without a fetch we'd miss a branch pushed from another machine
+              # and fork a second one with the same name.
+              git fetch origin 2>/dev/null
+              if git show-ref --verify --quiet "refs/remotes/origin/$branch"
+                git worktree add --track -b "$branch" "$wt_path" "origin/$branch"
+              else
+                git worktree add -b "$branch" "$wt_path" "$base_branch"
+              end
             end
             or begin; echo "wt: failed to create worktree"; return 1; end
             echo "Created worktree at $wt_path (from $base_branch)"

--- a/modules/dev/git.nix
+++ b/modules/dev/git.nix
@@ -47,6 +47,19 @@ mkUserModule {
               # every status caller inherits: the prompt, the wt pickers, wtrm.
               # APFS supports it (git update-index --test-untracked-cache).
               untrackedCache = true;
+              # Let an FSEvents daemon answer "what changed?" instead of
+              # rescanning the working tree. Picks up where untrackedCache
+              # stops: ~86ms -> ~38ms on the same 36k-file worktree, and the
+              # prompt pays that on *every* command, so it's felt far more
+              # than in any one tool.
+              #
+              # Each linked worktree gets its own daemon (~9MB), so a repo
+              # with N worktrees idles N of them — fine at ~17, worth a look
+              # if that ever reaches the hundreds.
+              #
+              # Needs git > 2.35.1 for the boolean form, and 2.47.1 for a
+              # macOS race fix. We pin pkgs.git above, currently 2.53.
+              fsmonitor = true;
             };
           };
         };


### PR DESCRIPTION
`wt`'s picker walked worktrees serially: ~150ms each, ~2.5s across monobloco's 17. The obvious fix is parallelism, and a note in `wt-rows` said it had already been tried and abandoned — 1.7x, I/O-bound, not worth it.

That measurement was right. The conclusion wasn't.

What the parallel workers contended on was the per-worktree working-tree scan. `core.fsmonitor` deletes that scan instead of sharing it out, and with the scan gone there's nothing left to serialise on, so the two compound rather than overlap:

| | time | vs serial |
|---|---|---|
| serial, no fsmonitor (before) | 2571 ms | 1x |
| parallel alone, `-P 16` | 1474 ms | 1.7x |
| `core.fsmonitor` alone | 757 ms | 3.4x |
| **both (after)** | **126 ms** | **20x** |

End-to-end on the built artifact: **2358 ms → 164 ms**.

## Commits

**`perf(git)`: let an fsmonitor daemon answer status**

The one that matters most, and not because of `wt` — the starship prompt calls `git status` on every command, so it pays this constantly. ~86ms → ~38ms in a 36k-file worktree.

Costs one daemon per linked worktree (~9MB), so ~150MB idle at monobloco's 17. Fine now; worth revisiting only in the hundreds.

**`perf(worktree)`: build the picker rows in parallel**

`xargs -P ncpu`. Only pays off because of the commit above.

Rows now arrive in nondeterministic order, so the sort no longer leans on stability falling back to the glob's alphabetical order — both keys are explicit (epoch desc, then name). Getting that wrong wouldn't corrupt anything, it would reshuffle rows under the cursor when the async pass swaps in.

**`perf(worktree)`: skip `wt`'s fetch when the branch is already local**

Worktree creation always ran `git fetch origin` first — ~2.7s blocking — to feed a refs/remotes lookup. The local check goes first now and answers offline, which covers re-creating a worktree you deleted.

The fetch still runs when there's no local branch, since that's the case where the remote changes the outcome: skipping it would fork a second branch over one pushed from another machine. `ls-remote` isn't an alternative — ~3.8s for a single ref, slower than the full fetch, because the cost is connection setup.

## Verification

- `wt-rows` output **byte-identical** to the serial version across the full 18-row picker, both `--fast` and full modes
- Row order **stable across 6 consecutive runs** (only drift is `%cr` ticking, "61 minutes ago" → "62")
- `--fast` and full passes agree on ordering, so the fzf swap can't reshuffle
- `shellcheck` clean; `wt-rows.drv` builds (shellcheck runs at build time)
- `wt.fish` builds; `fish --no-execute` clean on the rewritten function
- `statix check` clean, `nixfmt` applied, `nix flake check` passes
- `nix build .#darwinConfigurations.vega.system` succeeds

## Risk

The fetch reorder is the only behavioural change and is isolated in its own commit for a clean revert. The other two are pure performance with identical output.
