### PR TITLE
fix(tmux): scope agent session ownership to the agents/* prefix

### DIFF
--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -223,14 +223,15 @@ mkUserModule {
         display-message -p '#S'` tells you which session you are in; a
         `parent/branch` name means it is a git worktree on that branch.
 
-        Every session you did not create is mine. Never kill, rename, detach,
-        or send-keys to one.
-
-        Create your own freely — windows, panes, sessions — for dev servers, log
+        Create your own windows, panes, and sessions freely — dev servers, log
         tails, anything long-running or interactive that would block your shell.
-        Name every session `agents/<name>`. Always detached:
+        Name every session `agents/<name>`, always detached:
         `tmux new-session -d -s agents/<name>` (you are already inside tmux, so
-        an attached `new-session` errors). Kill them when you are done.
+        an attached `new-session` errors).
+
+        Sessions named `agents/*` are yours: use and kill them freely, including
+        leftovers from earlier runs. Every other session is mine — never kill,
+        rename, detach, or send-keys to one.
       '';
 
       programs.tmux = {


### PR DESCRIPTION
Follow-up to #606.

That PR told agents "every session you did not create is mine". An agent cannot verify that — it has no memory across runs. A leftover `agents/dev-server` from an earlier run reads as *not mine to touch*, so the rule forbade cleaning up exactly the garbage that needs cleaning, and leaks became permanent.

Key the rule on the prefix instead. Any agent can check it with one `tmux ls`:

> Sessions named `agents/*` are yours: use and kill them freely, including leftovers from earlier runs. Every other session is mine — never kill, rename, detach, or send-keys to one.

Same safety boundary, and cleanup is now legal. "including leftovers from earlier runs" is load-bearing — without it `agents/*` still reads as "the ones I made" and the fix doesn't land.

Also folds the two paragraphs together (the old pair claimed `agents/*` twice) and leads with the capability so the hard boundary lands last.

## Known and accepted

With parallel agents, B can now kill A's *live* `agents/dev-server`. Blast radius is a restarted dev server, and the wording grants permission rather than instructing a sweep. Guarding it properly needs liveness detection — more machinery than the leak is worth.

No reaper for stale `agents/*` either. Add one when they actually pile up.

## Verification

- `nixfmt` clean, `statix check` clean
- `nix eval .#darwinConfigurations.vega.config.home-manager.users.fernando.xdg.configFile."opencode/AGENTS.md".text` — renders with indentation stripped, still concatenates correctly alongside the ADHD and fish sections