### PR TITLE
feat(screen-studio): add Screen Studio to vega/fernando

### DIFF
--- a/modules/media/screen-studio.nix
+++ b/modules/media/screen-studio.nix
@@ -1,0 +1,5 @@
+{ mkUserModule, ... }:
+mkUserModule {
+  name = "screen-studio";
+  casks = [ "screen-studio" ];
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -120,6 +120,7 @@ mkUser {
   # Media
   iina.enable = true;
   obs.enable = true;
+  "screen-studio".enable = true;
   spotify.enable = true;
   stremio.enable = true;
   affinity.enable = true;


### PR DESCRIPTION
Adds the `screen-studio` Homebrew cask as a `mkUserModule` and enables it for vega/fernando.

Screen recorder + editor, so it lands in `modules/media/` next to `obs`.

Verified: `nixfmt`, `statix check`, and `nix eval` of `darwinConfigurations.vega.config.homebrew.casks` shows `screen-studio` present.