### PR TITLE
feat(tmux): group the PR panel into dependency trees and rank by review cost

### DIFF
--- a/modules/cli/tmux/pr.nix
+++ b/modules/cli/tmux/pr.nix
@@ -28,6 +28,7 @@ let
   # snooze list is not, so it lives in XDG state and survives reboots.
   cache = ''"''${TMPDIR:-/tmp}/tmux-pr.json"'';
   ignoreFile = ''"$HOME/.local/state/tmux-pr/ignored"'';
+  shapesFile = ''"$HOME/.local/state/tmux-pr/shapes.json"'';
   viewFile = ''"''${TMPDIR:-/tmp}/tmux-pr.view"'';
   showFile = ''"''${TMPDIR:-/tmp}/tmux-pr.show"'';
 
@@ -46,6 +47,49 @@ let
     ($ign | split("\n") | map(select(length > 0) | split("\t") | { key: .[0], value: (.[1] // "") }) | from_entries) as $ign
     | def snoozed: $ign[.url] as $at | $at != null and ($at == "" or $at == .updated);
       def live: map(select(snoozed | not));
+  '';
+
+  # A review request names the branch it targets, not the PR that made that
+  # branch. The six PostHog service migrations consequently arrived as six
+  # unrelated diffs until their otherwise-invisible setup PR was included.
+  jqTree = ''
+    def ref:
+      if (.head // "") == "" then null else .repo + "\u0000" + .head end;
+    def base_ref:
+      if (.base // "") == "" then null else .repo + "\u0000" + .base end;
+    def children($nodes; $parent):
+      [ $nodes[] | select($parent != null and base_ref == $parent) ]
+      | sort_by(.updated) | reverse;
+    def tree($nodes; $node; $depth):
+      $node as $current
+      | ($current + { depth: $depth })
+      , (children($nodes; ($current | ref))[] | tree($nodes; .; ($depth + 1)));
+    def tree_roots($nodes):
+      [ $nodes[]
+        | . as $node
+        | select(
+            (($node | base_ref) as $base
+             | ($base != null and ($nodes | any(ref == $base)))
+            )
+            | not
+          )
+      ];
+    def tree_forest($nodes):
+      [ tree_roots($nodes)[] as $root
+        | [ tree($nodes; $root; 0) ] as $rows
+        | {
+            updated: ($rows | map(.updated) | max),
+            members: ($rows | length),
+            rows: $rows,
+            treeRoot: ($root | ref)
+          }
+      ]
+      | sort_by(.updated) | reverse
+      | .[]
+      | .members as $members
+      | .treeRoot as $treeRoot
+      | .rows[]
+      | . + { members: $members, treeRoot: $treeRoot };
   '';
 
   # One request for both lists. Measured cost: 1 point of the 5000/hr GraphQL
@@ -71,6 +115,170 @@ let
       tmp=$(mktemp) || exit 0
       trap 'rm -f "$tmp"' EXIT
 
+      # GitHub's review queue omits the PR which created a stack's base branch.
+      # Resolve only those missing bases, repository by repository: branch names
+      # repeat across repos often enough that a global lookup manufactures trees.
+      resolve_parents() {
+        local work state frontier seen next_seen round parents next_state repos bases
+        local depth=0 repo branch query term old_count new_count
+
+        work=$(mktemp -d) || return 1
+        state="$work/state.json"
+        frontier="$work/frontier.json"
+        seen="$work/seen.json"
+        next_seen="$work/next-seen.json"
+        round="$work/round.json"
+        parents="$work/parents.json"
+        next_state="$work/next-state.json"
+        repos="$work/repos"
+        bases="$work/bases"
+
+        cp "$tmp" "$state" || {
+          rm -rf "$work"
+          return 1
+        }
+        printf '[]' >"$seen"
+
+        fetch_parent_batch() {
+          local repo="$1" response="$work/response.json"
+          shift
+
+          if ! gh pr list -R "$repo" --state open --limit 100 "$@" \
+            --json number,title,isDraft,createdAt,updatedAt,url,author,baseRefName,headRefName \
+            >"$response" 2>/dev/null; then
+            return 1
+          fi
+          if ! jq -e 'type == "array"' "$response" >/dev/null 2>&1; then
+            return 1
+          fi
+          jq --arg repo "$repo" '
+            [ .[] | {
+                repo: $repo,
+                number: .number,
+                title: .title,
+                author: (.author.login // ""),
+                created: .createdAt,
+                updated: .updatedAt,
+                url: .url,
+                draft: .isDraft,
+                decision: "",
+                ci: "",
+                base: .baseRefName,
+                head: .headRefName,
+                context: true
+              }
+            ]
+          ' "$response" >>"$round" || return 1
+        }
+
+        # ponytail: ancestry stops after eight hops; raise this ceiling if a
+        # real review stack exceeds it, rather than turning every refresh into
+        # an unbounded search after a malformed branch cycle.
+        while [ "$depth" -lt 8 ]; do
+          if ! jq --slurpfile seen "$seen" '
+            ($seen[0]) as $seen
+            | .review as $known
+            | ($known | map(.repo + "\u0000" + .head)) as $heads
+            | [ $known[]
+                | . as $candidate
+                | select($candidate.base != "")
+                | select(($heads | index($candidate.repo + "\u0000" + $candidate.base)) | not)
+                | { repo: $candidate.repo, base: $candidate.base }
+                | . as $candidate
+                | select(($seen | index($candidate)) | not)
+                | $candidate
+              ]
+            | unique_by([.repo, .base])
+          ' "$state" >"$frontier"; then
+            rm -rf "$work"
+            return 1
+          fi
+
+          if jq -e 'length == 0' "$frontier" >/dev/null 2>&1; then
+            break
+          fi
+          if ! jq -s '.[0] + .[1] | unique' "$seen" "$frontier" >"$next_seen"; then
+            rm -rf "$work"
+            return 1
+          fi
+          mv "$next_seen" "$seen"
+
+          : >"$round"
+          jq -r '.[].repo' "$frontier" | sort -u >"$repos" || {
+            rm -rf "$work"
+            return 1
+          }
+          while IFS= read -r repo; do
+            [ -n "$repo" ] || continue
+            jq -r --arg repo "$repo" '.[] | select(.repo == $repo) | .base' "$frontier" >"$bases" || {
+              rm -rf "$work"
+              return 1
+            }
+            query="is:open"
+            while IFS= read -r branch; do
+              [ -n "$branch" ] || continue
+              term=" head:$branch"
+              # GitHub cuts search strings at about 256 bytes. 240 leaves room
+              # for its own parsing without wasting one request per branch.
+              if [ "$query" = "is:open" ] && [ $((''${#query} + ''${#term})) -gt 240 ]; then
+                fetch_parent_batch "$repo" --head "$branch" || {
+                  rm -rf "$work"
+                  return 1
+                }
+                continue
+              fi
+              if [ "$query" != "is:open" ] && [ $((''${#query} + ''${#term})) -gt 240 ]; then
+                fetch_parent_batch "$repo" --search "$query" || {
+                  rm -rf "$work"
+                  return 1
+                }
+                query="is:open"
+              fi
+              query="$query$term"
+            done <"$bases"
+            if [ "$query" != "is:open" ]; then
+              fetch_parent_batch "$repo" --search "$query" || {
+                rm -rf "$work"
+                return 1
+              }
+            fi
+          done <"$repos"
+
+          if ! jq -s 'add // []' "$round" >"$parents"; then
+            rm -rf "$work"
+            return 1
+          fi
+          old_count=$(jq '.review | length' "$state") || {
+            rm -rf "$work"
+            return 1
+          }
+          if ! jq --slurpfile parents "$parents" '
+            .review as $known
+            | ($known | map(.url)) as $urls
+            | .review += [
+                ($parents[0] | unique_by(.url))[]
+                | select(.url as $url | ($urls | index($url)) | not)
+              ]
+          ' "$state" >"$next_state"; then
+            rm -rf "$work"
+            return 1
+          fi
+          new_count=$(jq '.review | length' "$next_state") || {
+            rm -rf "$work"
+            return 1
+          }
+          mv "$next_state" "$state"
+          [ "$new_count" -gt "$old_count" ] || break
+          depth=$((depth + 1))
+        done
+
+        cp "$state" "$tmp" || {
+          rm -rf "$work"
+          return 1
+        }
+        rm -rf "$work"
+      }
+
       gh api graphql \
         -f query='
           query {
@@ -86,9 +294,18 @@ let
             number
             title
             isDraft
+            createdAt
             updatedAt
             url
             author { login }
+            baseRefName
+            headRefName
+            additions
+            deletions
+            changedFiles
+            # ponytail: the first 100 paths cover the useful directory hint;
+            # paginate only if broad PRs make the model fall back to title scope.
+            files(first: 100) { nodes { path } }
             reviewDecision
             statusCheckRollup { state }
             viewerLatestReview { state }
@@ -99,11 +316,47 @@ let
             number: .number,
             title:  .title,
             author: (.author.login // ""),
+            created: .createdAt,
             updated: .updatedAt,
             url:    .url,
             draft:  .isDraft,
             decision: (.reviewDecision // ""),
-            ci:     (.statusCheckRollup.state // "")
+            ci:     (.statusCheckRollup.state // ""),
+            base:   .baseRefName,
+            head:   .headRefName,
+            additions: .additions,
+            deletions: .deletions,
+            changedFiles: .changedFiles,
+            # A conventional-commit scope sent the model to the wrong area,
+            # but the first two path components are worse: in this monorepo
+            # they are always "js/apps" or "python/services" — the layout,
+            # not the work. Dropping the layout words and the app name leaves
+            # "features/patients" and "infra/audio-recorder", which is what
+            # the shape prompt was actually calibrated against.
+            # ponytail: a fixed word list, not a real path parser. Add words
+            # here if a new language root shows up.
+            files: (
+              [
+                .files.nodes[]?.path
+                | split("/")
+                | .[0:-1]
+                | map(
+                    select(
+                      IN(
+                        "js", "apps", "src", "python", "services",
+                        "packages", "libs", "components",
+                        "test", "tests", "__tests__"
+                      ) | not
+                    )
+                  )
+                | (if length > 1 then .[1:4] else .[0:1] end)
+                | select(length > 0)
+                | join("/")
+              ]
+              | unique
+              | .[0:8]
+            ),
+            context: false
           };
           # Drop anything you have already reviewed. A team review request does
           # not always clear when one member reviews, so these linger in the
@@ -126,8 +379,164 @@ let
       # expired token otherwise blanks the status bar, which reads exactly like
       # "you have no review requests" — the one lie this must never tell.
       if [ -s "$tmp" ] && jq -e 'has("review")' "$tmp" >/dev/null 2>&1; then
+        # Parent lookups are supplemental. A partial GitHub failure must leave
+        # the original queue intact rather than turning a status-bar outage into
+        # an empty review list.
+        resolve_parents || true
         mv "$tmp" "$CACHE"
+        # Classification can take more than 300s. Publishing the queue first
+        # keeps a slow model from turning a GitHub refresh into a frozen popup.
+        ${tmux-pr-shape}/bin/tmux-pr-shape >/dev/null 2>&1 &
       fi
+    '';
+  };
+
+  # A 1,400-line mechanical refactor took ten minutes; a 200-line datalayer
+  # permission change took an hour. The queue needs the intent-to-diff gap,
+  # not another size column.
+  tmux-pr-shape = pkgs.writeShellApplication {
+    name = "tmux-pr-shape";
+    bashOptions = [ ];
+    runtimeInputs = with pkgs; [
+      coreutils
+      jq
+      opencode
+    ];
+    text = ''
+            CACHE=${cache}
+            SHAPES=${shapesFile}
+            LOCK="$SHAPES.lock"
+
+            [ -s "$CACHE" ] || exit 0
+            mkdir -p "$(dirname "$SHAPES")" || exit 0
+
+            # The model can outlive more than one 2-minute refresh. Without this
+            # lock, each refresh would buy the same batch while the first run waits.
+            if ! mkdir "$LOCK" 2>/dev/null; then
+              exit 0
+            fi
+
+            work=$(mktemp -d) || {
+              rmdir "$LOCK" 2>/dev/null || true
+              exit 0
+            }
+            next=""
+            cleanup() {
+              rm -rf "$work"
+              rm -f "$next"
+              rmdir "$LOCK" 2>/dev/null || true
+            }
+            trap cleanup EXIT
+
+            old="$work/old.json"
+            selected="$work/selected.json"
+            prompt="$work/prompt"
+            response="$work/response"
+            merged="$work/merged.json"
+
+            if [ -f "$SHAPES" ] && jq -e 'type == "object"' "$SHAPES" >/dev/null 2>&1; then
+              cp "$SHAPES" "$old" || exit 0
+            else
+              printf '{}' >"$old"
+            fi
+
+            # At ~$0.003 per full 40-PR pass on Haiku, updatedAt-keyed caching keeps
+            # this cheap enough to forget. Without it, the 2-minute refresh would
+            # re-run unchanged PRs continuously.
+            #
+            # ponytail: entries for closed PRs remain in state; a few hundred stale
+            # records cost less than one model call, so prune only if the file matters.
+            jq --slurpfile shapes "$old" '
+              def plain: tostring | gsub("[\\t\\r\\n]+"; " ");
+              def directories:
+                .files // []
+                | if length == 0 then "unknown" else join(", ") end;
+              [ .review[]
+                | select(.context != true)
+                | select(($shapes[0][.url].updated // null) != .updated)
+                | {
+                    url: .url,
+                    updated: .updated,
+                    input: (
+                      "#\(.number) @\(.author | plain) \(.title | plain)"
+                      + "\n+\(.additions // 0)/-\(.deletions // 0) in \(.changedFiles // 0) files | \(directories)"
+                      + "\nURL: \(.url)"
+                    )
+                  }
+              ]
+            ' "$CACHE" >"$selected" || exit 0
+
+            jq -e 'length > 0' "$selected" >/dev/null 2>&1 || exit 0
+
+            cat >"$prompt" <<'PROMPT'
+      Classify GitHub PR review shape and review cost.
+
+      Governing question: does the stated intent predict the code?
+      - If the title tells you what the diff contains (flag flip, rename, bump, same change applied N times), it is confirmation and cheap NO MATTER THE SIZE. A 4000-line mechanical refactor can be a 10-minute review.
+      - If the code could hold decisions the title does not imply (new behaviour, new boundaries, auth, data access, retention, PII, migrations), it must actually be read, and 200 lines can be an hour.
+
+      SIZE IS NOT COST. Do not rank by lines changed.
+
+      SHAPE, exactly one of:
+        bump           dependency/lockfile churn
+        flag           feature-flag flip, config, constant
+        mechanical     rename/move/refactor with no behaviour change
+        localized-fix  a bug fix inside one existing component
+        known-feature  new feature in an area that already works this way
+        new-surface    new subsystem, new integration, new public behaviour
+        sensitive      touches auth, permissions, data access, retention, or PII
+        unknown        too vague to infer
+
+      sensitive means the diff itself changes an authorization, data-access, retention or PII rule — NOT merely that it touches a service that has such rules elsewhere. A UI change in an app that also contains auth code is not sensitive.
+
+      COST, exactly one of: 2m 10m 30m 1h+
+
+      Output one line per PR: <url>\t<shape>\t<cost>
+      Output machine-readable TSV only, with no prose.
+      Do not judge whether code is good. Do not recommend approving or rejecting anything. If too vague to infer, emit unknown and 30m.
+
+      Each PR has its URL after its two summary lines. Use that exact URL in the output.
+
+      PRs:
+      PROMPT
+            jq -r '.[].input' "$selected" >>"$prompt" || exit 0
+
+            # This runs in an empty directory: the prompt supplies all the model may
+            # see, and the throwaway session does not become noise in a PR repository.
+            if ! opencode run --dir "$work" --title "tmux PR shape" -m "anthropic/claude-haiku-4-5" "$(<"$prompt")" \
+              >"$response" 2>/dev/null; then
+              exit 0
+            fi
+
+            # Models have wrapped TSV in prose and dropped three of forty PRs. Keep
+            # the last good entry for every malformed or missing result; its updated
+            # timestamp prevents a stale guess from reaching the popup.
+            jq -Rrn --slurpfile old "$old" --slurpfile selected "$selected" '
+              reduce inputs as $line (
+                { shapes: $old[0], added: 0 };
+                ($line | split("\t")) as $fields
+                | if ($fields | length) == 3
+                     and (["bump", "flag", "mechanical", "localized-fix", "known-feature", "new-surface", "sensitive", "unknown"] | index($fields[1]))
+                     and (["2m", "10m", "30m", "1h+"] | index($fields[2]))
+                  then ($selected[0] | map(select(.url == $fields[0])) | .[0]) as $pr
+                    | if $pr == null
+                      then .
+                      else .shapes[$fields[0]] = {
+                        shape: $fields[1],
+                        cost: $fields[2],
+                        updated: $pr.updated
+                      } | .added += 1
+                      end
+                  else .
+                  end
+              )
+            ' "$response" >"$merged" || exit 0
+
+            jq -e '.added > 0' "$merged" >/dev/null 2>&1 || exit 0
+            next=$(mktemp "$SHAPES.tmp.XXXXXX") || exit 0
+            jq '.shapes' "$merged" >"$next" || exit 0
+            mv "$next" "$SHAPES"
+            next=""
     '';
   };
 
@@ -167,10 +576,11 @@ let
       [ -f "$CACHE" ] || exit 0
 
       # The count never counts snoozed PRs, whatever the popup happens to be
-      # showing: `s` is a way to look at them, not a way to wake them.
+      # showing: `s` is a way to look at them, not a way to wake them. Context
+      # parents make a tree readable, but were never assigned to you.
       n=$(jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" '
         ${jqIgnore}
-        .review | live | length
+        .review | map(select(.context != true)) | live | length
       ' "$CACHE" 2>/dev/null) || exit 0
 
       case "''${n:-}" in "" | *[!0-9]*) exit 0 ;; esac
@@ -200,6 +610,7 @@ let
     text = ''
       CACHE=${cache}
       IGNORE=${ignoreFile}
+      SHAPES=${shapesFile}
       VIEW=${viewFile}
       SHOW=${showFile}
 
@@ -214,13 +625,69 @@ let
       # @tsv escapes tab/newline/backslash only, so the ANSI escapes below
       # survive it intact.
       render() {
-        jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" --arg view "$1" --arg show "$2" '
+        local shapes
+        # A partial write must look exactly like no classifier: the popup is
+        # useful before its first model result, and never gets to depend on it.
+        shapes=$(jq -c 'if type == "object" then . else {} end' "$SHAPES" 2>/dev/null) || shapes='{}'
+
+        jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" --argjson shapes "$shapes" --arg view "$1" --arg show "$2" '
           ${jqIgnore}
+          ${jqTree}
 
             def dim: "\u001b[2m"  + . + "\u001b[0m";
             def red: "\u001b[31m" + . + "\u001b[0m";
             def grn: "\u001b[32m" + . + "\u001b[0m";
             def yel: "\u001b[33m" + . + "\u001b[0m";
+
+            def shape_badge:
+              ($shapes[.url] // null) as $shape
+              | if .context == true or $shape == null or $shape.updated != .updated
+                then ""
+                elif $shape.shape == "sensitive"
+                  then ($shape.cost + " " + $shape.shape + "  " | red)
+                else ($shape.cost + " " + $shape.shape + "  " | dim)
+                end;
+
+            # #5191 was created 59d ago and requested review 53d ago, but an
+            # active author left updatedAt reading 8d. That hid up to 45d of
+            # waiting, which is the opposite of a queue tiebreaker.
+            def review_cost:
+              ($shapes[.url] // null) as $shape
+              | if .context == true or $shape == null or $shape.updated != .updated
+                then "30m"
+                else $shape.cost
+                end;
+            def cost_minutes:
+              review_cost
+              | if   . == "2m"  then 2
+                elif . == "10m" then 10
+                elif . == "30m" then 30
+                else                  60
+                end;
+            def cost_band:
+              if   . <= 2  then 0
+              elif . <= 10 then 1
+              elif . <= 30 then 2
+              else              3
+              end;
+            def review_tree_forest($nodes):
+              [ tree_roots($nodes)[] as $root
+                | [ tree($nodes; $root; 0) ] as $rows
+                | ($rows | map(cost_minutes) | add) as $total
+                | {
+                    band: ($total | cost_band),
+                    created: ($rows | map(.created) | min),
+                    members: ($rows | length),
+                    rows: $rows,
+                    treeRoot: ($root | ref)
+                  }
+              ]
+              | sort_by([.band, .created])
+              | .[]
+              | .members as $members
+              | .treeRoot as $treeRoot
+              | .rows[]
+              | . + { members: $members, treeRoot: $treeRoot };
 
             def age:
               (now - (.updated | fromdateiso8601)) as $s
@@ -242,12 +709,23 @@ let
               else                                       "" end;
 
           .[$view]
-          | (if $show == "1" then . else live end)
-          | sort_by(.updated) | reverse
-          | .[]
+          | (if $show == "1" then . else live end) as $rows
+          | if $view == "review"
+            then review_tree_forest($rows)
+            else ($rows | sort_by(.updated) | reverse | .[] | . + { depth: 0, members: 1 })
+            end
           | [ .url,
-              ( ( ((.repo | split("/") | last) + "#" + (.number | tostring) | dim)
+              ( ( (if $view == "review" and .members > 1
+                    then (if .depth == 0
+                          then ("[" + (.members | tostring) + " PRs] " | dim)
+                          else (("  " * .depth) + "↳ " | dim)
+                          end)
+                    else ""
+                    end)
+                  + ((.repo | split("/") | last) + "#" + (.number | tostring) | dim)
                   + "  " + (if .draft then ("draft " | dim) else "" end)
+                  + (if .context then ("context " | dim) else "" end)
+                  + shape_badge
                   + .title
                   + "  "
                   + (if $view == "mine"
@@ -275,7 +753,7 @@ let
         local parts=()
         counts=$(jq -r --arg ign "$(cat "$IGNORE" 2>/dev/null)" --arg view "$v" '
           ${jqIgnore}
-          [ (.review | live | length),
+          [ (.review | map(select(.context != true)) | live | length),
             (.mine   | live | length),
             (.[$view] | map(select(snoozed)) | length) ] | @tsv
         ' "$CACHE" 2>/dev/null) || counts=""
@@ -291,7 +769,7 @@ let
           if [ -n "$s" ]; then tail=" · $z snoozed shown"; else tail=" · $z snoozed"; fi
         fi
         printf '%s · %s%s\n' "''${parts[@]}" "$tail"
-        printf 'enter open · x snooze · s show · u clear · / search · tab view · r refresh\n'
+        printf 'enter open · t tree · x snooze · s show · u clear · / search · tab view · r refresh\n'
       }
 
       # ── subcommands driven by fzf binds ──────────────────────────────────
@@ -357,9 +835,32 @@ let
           ;;
         --open)
           [ -n "''${2:-}" ] || exit 0
-          # gh resolves a PR url directly, so this needs no platform-specific
-          # opener and no cwd inside the repo.
-          gh pr view --web "$2" >/dev/null 2>&1 || true
+          # The row already carries the url, so opening it needs nothing from
+          # the GitHub API — but routing it through `gh` did. During a GitHub
+          # 503 every enter press became a silent no-op, because the failure
+          # is deliberately swallowed so a dead opener cannot kill the popup.
+          # The desktop opener has no network in its path; gh stays only as
+          # the fallback for hosts without one.
+          open "$2" >/dev/null 2>&1 || gh pr view --web "$2" >/dev/null 2>&1 || true
+          exit 0
+          ;;
+        --open-tree)
+          [ -n "''${2:-}" ] || exit 0
+          urls=$(jq -r --arg url "$2" '
+            ${jqTree}
+            .review as $rows
+            | [ tree_forest($rows) ] as $forest
+            | ($forest[] | select(.url == $url) | .treeRoot) as $tree_root
+            | $forest[] | select(.treeRoot == $tree_root) | .url
+          ' "$CACHE" 2>/dev/null) || urls=""
+          # Each opener returns only after handing the tab to the browser, so
+          # this preserves the root→leaf reading order in tabs. Same reason as
+          # --open for preferring the desktop opener: a whole tree silently
+          # failing to open is the worst version of that bug.
+          while IFS= read -r url; do
+            [ -n "$url" ] || continue
+            open "$url" >/dev/null 2>&1 || gh pr view --web "$url" >/dev/null 2>&1 || true
+          done <<<"$urls"
           exit 0
           ;;
       esac
@@ -390,6 +891,8 @@ let
       redraw='reload('"$self"' --list)+transform-header('"$self"' --header)'
       # shellcheck disable=SC2016  # {1} is fzf's placeholder, not a shell var
       b_open='execute-silent('"$self"' --open {1})'
+      # shellcheck disable=SC2016  # {1} is fzf's placeholder, not a shell var
+      b_tree='execute-silent('"$self"' --open-tree {1})'
       # shellcheck disable=SC2016
       b_snooze='execute-silent('"$self"' --snooze {1})+'"$redraw"
       b_show='execute-silent('"$self"' --show-toggle)+'"$redraw"
@@ -409,10 +912,10 @@ let
       # would quietly build up a "pae" in the prompt that looks like a search
       # doing nothing. Wiping it on change keeps the prompt honest; the bind has
       # to come off in search mode or it would eat the query as you type it.
-      b_search='unbind(change)+unbind(x)+unbind(s)+unbind(u)+unbind(r)+unbind(/)+clear-query+change-prompt(/ )+enable-search'
+      b_search='unbind(change)+unbind(t)+unbind(x)+unbind(s)+unbind(u)+unbind(r)+unbind(/)+clear-query+change-prompt(/ )+enable-search'
       # Back to menu mode: reload repopulates the full list, since disable-search
       # on its own freezes whatever subset the last query left behind.
-      b_esc_back='clear-query+disable-search+change-prompt(❯ )+rebind(change)+rebind(x)+rebind(s)+rebind(u)+rebind(r)+rebind(/)+'"$redraw"
+      b_esc_back='clear-query+disable-search+change-prompt(❯ )+rebind(change)+rebind(t)+rebind(x)+rebind(s)+rebind(u)+rebind(r)+rebind(/)+'"$redraw"
       # shellcheck disable=SC2016  # $FZF_PROMPT is fzf's, not bash's
       b_esc='transform~[ "$FZF_PROMPT" = "/ " ] && echo "'"$b_esc_back"'" || echo abort~'
 
@@ -427,6 +930,7 @@ let
         --color='pointer:green,prompt:green,info:dim,header:dim' \
         --header="$(header_line "$view" "$show")" \
         --bind "enter:$b_open" \
+        --bind "t:$b_tree" \
         --bind "x:$b_snooze" \
         --bind "s:$b_show" \
         --bind "u:$b_unignore" \


### PR DESCRIPTION
The PR panel was a recency-sorted list of 60+ items, which answers no question you have while looking at it. Everything below is measured against `Telepatia-AI/monobloco`, not assumed.

## Dependency trees

A review request names the branch it targets, never the PR that *created* that branch. So a stack arrives as N unrelated diffs whose bases do not exist in trunk, and GitHub says nothing about it.

Resolving parents upward found **10 trees covering 20 queued PRs — and 8 of those roots were never in the queue.**

```
[7 PRs] #8940  feat(analytics): add shared TypeScript clients      <- not in my queue
  |- #9003 . #9006
  |- #8972 -> #8975 -> #8984 -> #8994
```

`#8943`'s six-PR sibling set is unreadable without `#8931`, which GitHub never showed. `t` opens a whole tree root-first.

Teammates were already working around this by hand — `stack 2/4`, `surveys P1`, `stacked on #9722` are real PR titles.

## Shape and cost badges

Size is not review cost:

| PR | diff | cost |
|---|---|---|
| #10145 | +164/-1239, 33 files | `10m mechanical` |
| #9945 | small | `1h+ sensitive` |

A detached haiku pass labels each PR with a shape and a cost, cached on `updatedAt` so an unchanged PR is never reclassified (~$0.003 a full pass). It independently flagged the datalayer permission PRs as `sensitive` without being told this repo cares about that.

The model is never asked whether code is good, never recommends a decision, and nothing it produces leaves the terminal.

## Cost-band sorting

Cheapest first, oldest first within a band. Trees are priced by their *total* cost since you commit to the whole tree.

`updated` is deliberately not the age key: #5191 was created 59 days ago and requested 53 days ago, but reads 8 days by `updatedAt` because its author is active elsewhere.

## Failure behaviour

Badges are a left join and never gate a row. A PR the model drops, or has not seen yet, renders exactly as before. Nothing is ever hidden from the queue — the panel's existing rule that it must never imply an empty queue is preserved throughout.

`enter` no longer routes through the GitHub API to open a URL the row already carries; during a GitHub 503 every keypress was a silent no-op.

## Verification

- `nixfmt`, `statix check .`, and a full `nix build .#darwinConfigurations.vega.system` (the only thing that runs shellcheck on `writeShellApplication` text)
- All three known trees render correctly with their invisible roots present
- Classifier: invalidating one entry reclassifies exactly that one, 65 entries intact
- Every rendered row's first field is a valid URL, so `enter` cannot silently break

## Not included

Subject/affinity grouping. Three runs of an identical prompt yielded one stable group covering 2 PRs — the work genuinely is not clustered, and the groups that matter are already caught structurally by trees.
