### PR TITLE
chore(opencode-manager): remove the opencode session fork binding

### DIFF
--- a/modules/dev/opencode-manager/opencode-manager.nix
+++ b/modules/dev/opencode-manager/opencode-manager.nix
@@ -81,90 +81,6 @@ let
     '';
   };
 
-  # Resolve a tmux pane's opencode session ID.
-  # Reads @oc-sid from tmux pane options (set by the wrapper sidecar),
-  # falls back to DB query by directory.
-  # Exit 0 + stdout: session ID
-  # Exit 1: no mapping found
-  # Exit 2: pending (session not yet resolved — caller should retry)
-  # Usage: tmux-opencode-session <pane_id> [pane_path]
-  tmux-opencode-session = pkgs.writeShellApplication {
-    name = "tmux-opencode-session";
-    runtimeInputs = [
-      pkgs.sqlite
-      pkgs.tmux
-      tmux-git-root-path
-    ];
-    text = ''
-      set -eu
-
-      PANE_ID="''${1:?usage: tmux-opencode-session <pane_id> [pane_path]}"
-      PANE_PATH="''${2:-}"
-
-      # Primary: tmux pane option (set by the wrapper SSE sidecar). These
-      # options persist after opencode exits, so they are only trustworthy
-      # while the pane is still running it; otherwise fall through to the DB.
-      CMD=$(tmux display-message -p -t "$PANE_ID" '#{pane_current_command}' 2>/dev/null || true)
-      case "$CMD" in
-        *opencode*)
-          SID=$(tmux show-options -pv -t "$PANE_ID" @oc-sid 2>/dev/null || true)
-          if [[ -n "$SID" ]]; then
-            echo "$SID"
-            exit 0
-          fi
-          ;;
-      esac
-
-      # Fallback: DB query by directory (for legacy or non-wrapper panes)
-      if [[ -z "$PANE_PATH" ]]; then
-        PANE_PATH=$(tmux display-message -p -t "$PANE_ID" '#{pane_current_path}' 2>/dev/null || true)
-      fi
-      [[ -z "$PANE_PATH" ]] && exit 1
-
-      OPENCODE_DB="$HOME/.local/share/opencode/opencode.db"
-      [[ ! -f "$OPENCODE_DB" ]] && exit 1
-
-      GIT_ROOT=$(tmux-git-root-path "$PANE_PATH")
-      SID=$(sqlite3 "$OPENCODE_DB" \
-        "SELECT id FROM session WHERE directory = '$GIT_ROOT'
-         ORDER BY time_updated DESC LIMIT 1" 2>/dev/null || true)
-
-      if [[ -z "''${SID:-}" ]]; then
-        exit 1
-      fi
-
-      echo "$SID"
-    '';
-  };
-
-  tmux-opencode-fork-window = pkgs.writeShellApplication {
-    name = "tmux-opencode-fork-window";
-    runtimeInputs = [
-      pkgs.tmux
-      tmux-git-root-path
-      tmux-opencode-session
-    ];
-    text = ''
-      set -eu
-
-      PANE_ID="$1"
-      PANE_PATH="$2"
-
-      SESSION_ID=""
-      for _ in 1 2 3 4 5; do
-        SESSION_ID=$(tmux-opencode-session "$PANE_ID" "$PANE_PATH") && break
-        rc=$?
-        if [[ $rc -eq 2 ]]; then sleep 0.5; else exit 1; fi
-      done
-      [[ -z "$SESSION_ID" ]] && exit 1
-
-      GIT_ROOT=$(tmux-git-root-path "$PANE_PATH")
-      TMUX_SESSION=$(tmux display-message -p '#S')
-
-      tmux new-window -t "$TMUX_SESSION" -c "$GIT_ROOT" "opencode --session $SESSION_ID --fork"
-    '';
-  };
-
   tmux-agent-prompt = pkgs.writeShellApplication {
     name = "tmux-agent-prompt";
     bashOptions = [ ];
@@ -214,8 +130,6 @@ mkUserModule {
   home = {
     home.packages = [
       tmux-opencode-manager
-      tmux-opencode-session
-      tmux-opencode-fork-window
       tmux-spawn-agent
       tmux-agent-prompt
     ];
@@ -258,7 +172,6 @@ mkUserModule {
       set-hook -g after-kill-pane 'run-shell -b "${tmux-opencode-manager}/bin/tmux-opencode-manager notify dismiss-pane \"#{hook_arguments}\""'
       set-hook -g session-closed 'run-shell -b "${tmux-opencode-manager}/bin/tmux-opencode-manager notify dismiss-session #{session_name}"'
       bind-key 'a' display-popup -E -h 3 -w 60% -s 'bg=default' -S 'bg=default' "${tmux-agent-prompt}/bin/tmux-agent-prompt '#{pane_current_path}'"
-      bind-key 'f' run-shell "${tmux-opencode-fork-window}/bin/tmux-opencode-fork-window '#{pane_id}' '#{pane_current_path}'"
     '';
   };
 }


### PR DESCRIPTION
`prefix+f` forked the pane's opencode session into a new window. Never used, so it goes.

Removed:
- the `bind-key 'f'` binding
- `tmux-opencode-fork-window`, the script behind it
- `tmux-opencode-session`, the pane→session-id resolver that existed only to feed it

`prefix+f` is now free. `tmux-git-root-path` stays — still used by `tmux-spawn-agent` and `tmux.nix`.

Kept the `--fork` parsing in `modules/dev/opencode/server.nix`: that handles forks started from inside opencode's TUI, a different path.