### PR TITLE
fix(nvim): stop neo-tree racing itself open on startup

### DIFF
--- a/modules/editor/nvim/explorer.nix
+++ b/modules/editor/nvim/explorer.nix
@@ -56,23 +56,16 @@
         {
           plugin = vimPlugins.neo-tree-nvim;
           config = ''
-            -- Open neo-tree on startup
+            -- Open neo-tree on startup, but only when nvim was given a file.
+            -- ponytail: exactly one opener. A second one (BufReadPost) raced this
+            -- and fed neo-tree a duplicate filesystem_navigate while the first
+            -- split was still mounting, killing the winid nui was about to focus
+            -- ("Invalid window id" from nui/split/init.lua:184).
             vim.api.nvim_create_autocmd('VimEnter', {
               callback = function()
-                -- Only open if we're not opening a specific file via stdin or with args that are directories
                 if vim.fn.argc() == 0 then return end
                 -- ponytail: pcall so a broken/missing Neotree can't abort startup
                 pcall(vim.cmd, 'Neotree show right')
-              end,
-            })
-
-            -- Also open when entering a buffer (covers opening nvim with a file)
-            vim.api.nvim_create_autocmd('BufReadPost', {
-              once = true,
-              callback = function()
-                vim.schedule(function()
-                  pcall(vim.cmd, 'Neotree show right')
-                end)
               end,
             })
 


### PR DESCRIPTION
## The error

Neo-tree threw this on startup, repeatedly:

```
[Neo-tree ERROR] debounce filesystem_navigate error:
  .../nvim/site/pack/hm/start/nui.nvim/lua/nui/split/init.lua:184: Invalid window id: 1004
```

## Root cause

`explorer.nix` had **two** autocmds opening the tree for the same event:

| Autocmd | Guard | Fires when |
|---|---|---|
| `VimEnter` | `argc() == 0 → return` | nvim launched **with** a file argument |
| `BufReadPost` | `once = true` | first file buffer is read |

Launch `nvim somefile.nix` and both fire, so `Neotree show right` runs twice.

Neo-tree debounces `filesystem_navigate` at 100ms with `CALL_FIRST_AND_LAST`
([`filesystem/init.lua#L198-L204`](https://github.com/nvim-neo-tree/neo-tree.nvim/blob/main/lua/neo-tree/sources/filesystem/init.lua#L198-L204)),
so the second open lands while the first split is still mounting and closes the
window nui just created.

nui's `Split:_open_window()` then runs:

```lua
self.winid = vim.api.nvim_win_call(..., function() ... end)  -- winid 1004
vim.api.nvim_win_set_buf(self.winid, self.bufnr)
if self._.enter then
  vim.api.nvim_set_current_win(self.winid)   -- line 184, winid already dead
end
```

There is no `nvim_win_is_valid` guard at that call
([`nui/split/init.lua#L164-L190`](https://github.com/MunifTanjim/nui.nvim/blob/main/lua/nui/split/init.lua#L164-L190)),
so a stale winid raises instead of being skipped.

Same class as nvim-neo-tree/neo-tree.nvim#102 and nvim-neo-tree/neo-tree.nvim#1014,
where maintainers traced it to `navigate` firing twice and the window being "lost
in between" validation and focus.

## The fix

Delete the `BufReadPost` opener. `VimEnter` already covered the only case either
autocmd handled — nvim launched with a file argument — so there is no behaviour
change:

- `nvim somefile.nix` → tree opens (once now, instead of twice)
- `nvim` with no args → tree does not open, same as before

## Why not the other options

- **Bump `nui.nvim`** — already on `0.4.0`, its latest release. Nothing to gain.
- **Patch in an `nvim_win_is_valid` guard** — would paper over the duplicate
  navigate rather than remove it.
- **Disable `close_if_last_window` / `use_libuv_file_watcher`** — speculative, and
  costs real functionality. Revisit only if the error survives this.

## Verification

- `statix check .` — clean
- `nixfmt --check` — clean
- `nix flake check` — `all checks passed!` (byte-compiles the generated `init.lua`)
