### PR TITLE
feat(openclaw): manage OpenClaw through the first-party nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -122,6 +122,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "hermes-agent": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -176,6 +194,27 @@
         "owner": "nix-community",
         "repo": "home-manager",
         "rev": "6e92bf094d45bc33d754e2b0f75d9ca1827cc363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-openclaw",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783963347,
+        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
         "type": "github"
       },
       "original": {
@@ -268,6 +307,46 @@
         "type": "github"
       }
     },
+    "nix-openclaw": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager_2",
+        "nix-openclaw-tools": "nix-openclaw-tools",
+        "nixpkgs": "nixpkgs_2",
+        "qmd": "qmd"
+      },
+      "locked": {
+        "lastModified": 1786643324,
+        "narHash": "sha256-ighXL0KhBd1k/ia8+5xvvrsOuMI6VcfvSeaUaCuyPos=",
+        "owner": "openclaw",
+        "repo": "nix-openclaw",
+        "rev": "4a27671497057be5bf91cc38cdaebb3280b77220",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openclaw",
+        "repo": "nix-openclaw",
+        "type": "github"
+      }
+    },
+    "nix-openclaw-tools": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1778060041,
+        "narHash": "sha256-tXWkN1VnwFG8XlRqW/e7VwbKnUfyU9tB7YDm9QHJXTY=",
+        "owner": "openclaw",
+        "repo": "nix-openclaw-tools",
+        "rev": "4c1cee3c7eaf68f9de0f756be1484534f5bb5f34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openclaw",
+        "repo": "nix-openclaw-tools",
+        "type": "github"
+      }
+    },
     "nix-vscode-extensions": {
       "inputs": {
         "nixpkgs": [
@@ -290,15 +369,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
-        "owner": "nixos",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -322,6 +401,38 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1780749050,
         "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
@@ -338,7 +449,7 @@
     },
     "noctalia": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_4",
         "noctalia-qs": "noctalia-qs"
       },
       "locked": {
@@ -362,7 +473,7 @@
           "noctalia",
           "nixpkgs"
         ],
-        "systems": "systems",
+        "systems": "systems_2",
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
@@ -509,6 +620,32 @@
         "type": "github"
       }
     },
+    "qmd": {
+      "inputs": {
+        "flake-utils": [
+          "nix-openclaw",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nix-openclaw",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775429264,
+        "narHash": "sha256-bqIVaNRTa8H5vrw3RwsD7QdtTa0xNvRuEVzlzE1hIBQ=",
+        "owner": "tobi",
+        "repo": "qmd",
+        "rev": "65cd1b3fd02891d1ee0eefa751620918664fa321",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tobi",
+        "ref": "v2.1.0",
+        "repo": "qmd",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "brew-src": "brew-src",
@@ -523,8 +660,9 @@
         "homebrew-core": "homebrew-core",
         "homebrew-schpet-tap": "homebrew-schpet-tap",
         "nix-homebrew": "nix-homebrew",
+        "nix-openclaw": "nix-openclaw",
         "nix-vscode-extensions": "nix-vscode-extensions",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-nixos": "nixpkgs-nixos",
         "noctalia": "noctalia",
         "opencode": "opencode",
@@ -532,6 +670,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
@@ -546,7 +699,7 @@
         "type": "github"
       }
     },
-    "systems_2": {
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -606,7 +759,7 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,

--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,19 @@
       url = "github:kristianvast/hermes-claude-auth";
       flake = false;
     };
+
+    # First-party OpenClaw flake — upstream points Nix users here rather than
+    # at the nixpkgs package. Ships the home-manager module that owns the
+    # launchd gateway agent and renders ~/.openclaw/openclaw.json immutably.
+    #
+    # Deliberately NOT following our nixpkgs, and this is load-bearing: openclaw
+    # refuses to start on node < 22.22.3, their pin carries nodejs_22 = 22.23.1
+    # and ours carries 22.22.2. Building it against our nixpkgs yields a gateway
+    # that exits 1 and crash-loops under launchd. Their pin is also what upstream
+    # publishes to cache.garnix.io. Cost is a second nixpkgs in the lock.
+    nix-openclaw = {
+      url = "github:openclaw/nix-openclaw";
+    };
   };
 
   outputs =

--- a/modules/dev/openclaw.nix
+++ b/modules/dev/openclaw.nix
@@ -1,0 +1,84 @@
+{
+  inputs,
+  system,
+  mkUserModule,
+  ...
+}:
+let
+  # Reproduce the package set nix-openclaw builds internally: ITS nixpkgs pin
+  # plus ITS overlay, exactly as its flake does.
+  #
+  # Applying the overlay to OUR nixpkgs instead (the obvious move) rebuilds
+  # openclaw against our nodejs_22 = 22.22.2 — one patch below the >=22.22.3
+  # floor openclaw enforces at startup — so the gateway exits 1 and launchd
+  # crash-loops it. Their pin carries nodejs_22 = 22.23.1 deliberately. It also
+  # costs the binary cache: garnix publishes builds made against their pin, so
+  # rebuilding against ours misses every substitute.
+  openclawPkgs = import inputs.nix-openclaw.inputs.nixpkgs {
+    inherit system;
+    overlays = [ inputs.nix-openclaw.overlays.default ];
+  };
+in
+mkUserModule {
+  name = "openclaw";
+
+  system = {
+    # Alias the prebuilt attrs the home-manager module resolves off pkgs. It
+    # reads `pkgs.openclaw`, `pkgs.openclawPackages` (toolchain overrides, QMD)
+    # and `pkgs.openclawRuntimePlugins` internally, so setting
+    # `programs.openclaw.package` alone would leave those pointing at the
+    # nixpkgs build — which nixpkgs marks insecure ("uses LLMs to parse
+    # untrusted content while having full access to system by default") and
+    # refuses to evaluate.
+    nixpkgs.overlays = [
+      (_: _: {
+        inherit (openclawPkgs)
+          openclaw
+          openclaw-app
+          openclaw-gateway
+          openclawPackages
+          openclawRuntimePlugins
+          ;
+      })
+    ];
+
+    # Pre-built openclaw. The flake declares this cache in its own nixConfig,
+    # but flake nixConfig does not apply to inputs — without it here, every
+    # rebuild compiles a pnpm workspace with native addons (sharp, node-pty)
+    # from source. Upstream publishes packages.aarch64-darwin.openclaw here.
+    nix.settings = {
+      extra-substituters = [ "https://cache.garnix.io" ];
+      extra-trusted-public-keys = [
+        "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+      ];
+    };
+  };
+
+  home = {
+    imports = [ inputs.nix-openclaw.homeManagerModules.openclaw ];
+
+    programs.openclaw = {
+      enable = true;
+
+      # ponytail: workaround for an upstream bug, not decoration. When
+      # `instances` is empty, nix-openclaw synthesises a default instance as a
+      # plain attrset whose `appDefaults` omits `nixMode` — but config.nix reads
+      # `inst.appDefaults.nixMode` unconditionally on darwin, so a bare
+      # `enable = true` fails to evaluate on macOS. Declaring the instance routes
+      # it through the submodule type, which supplies every default (identical
+      # stateDir/logPath/gatewayPort, plus the missing nixMode). Upstream CI
+      # misses this because its macOS test declares instances.default too.
+      # Remove once nix-openclaw fixes defaultInstance.
+      instances.default.config = {
+        # The gateway binds loopback only (gateway.mode = "local", 127.0.0.1 and
+        # ::1 on 18789), so there is no network surface to authenticate and
+        # "none" costs nothing. The alternatives all mean a shared secret, and
+        # openclaw.json is a world-readable /nix/store path — a literal token
+        # there would be legible to every user on the machine. If this gateway
+        # is ever exposed beyond loopback, this must become "token" with the
+        # value supplied as a SecretRef (file/exec), never inline.
+        gateway.auth.mode = "none";
+      };
+    };
+  };
+}

--- a/modules/productivity/openclaw.nix
+++ b/modules/productivity/openclaw.nix
@@ -1,5 +1,0 @@
-{ mkUserModule, ... }:
-mkUserModule {
-  name = "openclaw";
-  casks = [ "openclaw" ];
-}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -41,6 +41,7 @@ mkUser {
     enable = true;
     server.autoAttach = false;
   };
+  openclaw.enable = true;
   playwright-cli.enable = true;
   opencode-manager.enable = true;
   # rtk.enable = true;


### PR DESCRIPTION
Replaces the Homebrew cask with the `nix-openclaw` home-manager module. The binary, `~/.openclaw/openclaw.json`, the launchd gateway agent and `OpenClaw.app` are now all Nix-managed.

The cask was `auto_updates`, so Homebrew never really managed it — the app updated itself out from under the config.

## Why not the nixpkgs package

`pkgs.openclaw` is marked insecure:

> Project uses LLMs to parse untrusted content, making it vulnerable to prompt injection, while having full access to system by default.

Using it needs a `permittedInsecurePackages` entry containing the exact version string, which breaks the build on every bump until it's hand-edited. Upstream points Nix users at their own flake, which carries no such marking and tracks a newer release (`2026.7.1-2` vs `2026.4.12`).

## Why the flake's nixpkgs is not followed

Load-bearing, not stylistic. openclaw refuses to start on node < 22.22.3:

| nixpkgs | `nodejs_22` |
| --- | --- |
| nix-openclaw's pin | 22.23.1 |
| ours | 22.22.2 |

Building against ours produces a gateway that exits 1 and crash-loops under launchd. The node path is baked into the wrapper (`exec "/nix/store/…-nodejs/bin/node"`), so no PATH or `runtimePackages` workaround exists. Their pin is also what upstream publishes to `cache.garnix.io`.

For the same reason the module **aliases their prebuilt package set** instead of applying `overlays.default` to our nixpkgs — the overlay silently substitutes our too-old node. Verified the aliased path is byte-identical to their own `packages.aarch64-darwin.openclaw`.

## Notes

- `instances.default = { }` is a workaround for an upstream bug: with `instances` empty, nix-openclaw synthesises a default instance whose `appDefaults` omits `nixMode`, while `config.nix` reads it unconditionally on darwin — so a bare `enable = true` fails to evaluate on macOS. Commented with a removal condition.
- `gateway.auth.mode = "none"`: the gateway binds loopback only, and `openclaw.json` is a world-readable `/nix/store` path, so an inline token would be readable by every user on the machine. Comment records that exposing it beyond loopback requires `"token"` via a SecretRef.
- `flake.lock` is a pure addition — `nixpkgs` and `nixpkgs-nixos` revs are unchanged, root inputs 18 → 19.

## Verification

- `statix check .` clean, `nixfmt` applied
- full config evaluates
- rebuilt and running: gateway PID up, last exit status `0`, node **22.23.1**, `HTTP 200` on `127.0.0.1:18789`
- provider auth usable; opencode's `anthropic` and `openai` OAuth grants both still valid and untouched