### PR TITLE
feat(gum): bind shift+enter to insert a newline in gum write

### DIFF
--- a/modules/cli/gum/gum.nix
+++ b/modules/cli/gum/gum.nix
@@ -1,0 +1,64 @@
+{
+  mkUserModule,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  version = "2.0.0";
+
+  # gum hardcodes ctrl+j for "insert newline" and exposes no keymap surface at
+  # all: no flag, no GUM_* env var, no config file. charmbracelet/gum#727 (the
+  # issue) and #822 (the PR) are both still open, and v2.0.0's write/options.go
+  # still carries exactly one behavioural flag. Patching is the only lever.
+  #
+  # This needs v2 specifically, not just the patch. nixpkgs ships gum 0.17.0,
+  # built on bubbletea v1.3.6, which cannot receive shift+enter at all — the
+  # terminal collapses it to a bare CR, so binding the string would be inert.
+  # v2.0.0 moved to bubbletea v2, which speaks the kitty keyboard protocol, so
+  # "shift+enter" became a key string that can actually match.
+  #
+  # Built from scratch rather than `pkgs.gum.overrideAttrs` so that nothing in
+  # here reads `pkgs.gum` — the overlay below replaces that attribute, and
+  # referring to it while defining it is an infinite recursion.
+  gum-v2 = pkgs.buildGoModule {
+    pname = "gum";
+    inherit version;
+
+    src = pkgs.fetchFromGitHub {
+      owner = "charmbracelet";
+      repo = "gum";
+      rev = "v${version}";
+      hash = "sha256-M1eLi/Jc8QCc6Mai3Nc42MXRnl5ucafQMiOFL3kLoz4=";
+    };
+
+    vendorHash = "sha256-gvTQQOkCVIyKE27dgeQAPM4ZBV2XZnjRtqmEwPbY3Gc=";
+
+    patches = [ ./shift-enter.patch ];
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X=main.Version=${version}"
+    ];
+
+    meta = {
+      description = "Glamorous shell scripts (v2, patched: shift+enter inserts a newline)";
+      homepage = "https://github.com/charmbracelet/gum";
+      license = lib.licenses.mit;
+      mainProgram = "gum";
+    };
+  };
+in
+mkUserModule {
+  name = "gum";
+
+  # modules/dev/linear.nix bakes `pkgs.gum` into its script's PATH at build
+  # time, and modules/cli/todoist.nix lists it in runtimeInputs, so putting the
+  # patched build only in home.packages would leave those scripts pointing at
+  # the unpatched 0.17.0 store path. Override the package set instead, and
+  # every consumer follows.
+  system.nixpkgs.overlays = [ (_: _: { gum = gum-v2; }) ];
+
+  home.home.packages = [ gum-v2 ];
+}

--- a/modules/cli/gum/shift-enter.patch
+++ b/modules/cli/gum/shift-enter.patch
@@ -1,0 +1,15 @@
+diff --git a/write/write.go b/write/write.go
+index 02adf1b..17437e5 100644
+--- a/write/write.go
++++ b/write/write.go
+@@ -43,8 +43,8 @@ func (k keymap) ShortHelp() []key.Binding {
+ func defaultKeymap() keymap {
+ 	km := textarea.DefaultKeyMap()
+ 	km.InsertNewline = key.NewBinding(
+-		key.WithKeys("ctrl+j"),
+-		key.WithHelp("ctrl+j", "insert newline"),
++		key.WithKeys("ctrl+j", "shift+enter"),
++		key.WithHelp("shift+enter", "insert newline"),
+ 	)
+ 	return keymap{
+ 		KeyMap: km,

--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -283,6 +283,13 @@ mkUserModule {
           # Pass through extended keys (CSI u / kitty keyboard protocol)
           # Required for Cmd+P, Cmd+Shift+F etc. from Ghostty → tmux → nvim
           set -g extended-keys on
+          # `extended-keys on` only governs what tmux sends INWARD to panes. To
+          # receive disambiguated keys from the outer terminal, tmux must also
+          # believe that terminal supports them and request it — that is the
+          # `extkeys` feature. Ghostty (TERM=xterm-ghostty) matches the stock
+          # `xterm*` entry, which lacks extkeys, so shift+enter arrives as a
+          # bare CR and is indistinguishable from enter without this line.
+          set -as terminal-features ",xterm-ghostty:extkeys"
           set -g allow-passthrough on
 
           # Copy to system clipboard from vi copy mode

--- a/modules/cli/todoist.nix
+++ b/modules/cli/todoist.nix
@@ -289,8 +289,8 @@ mkUserModule {
               fi
 
               # The one field quickadd could never carry. show-help stays on here
-              # because enter submits and ctrl+j makes a newline, which is the
-              # only binding in this form you would not already guess.
+              # because enter submits and shift+enter makes a newline, which is
+              # the only binding in this form you would not already guess.
               draw
               notes=$(gum write --header "$(pad notes)" \
                 --placeholder "context, links, the first step…" \

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -14,6 +14,7 @@ mkUser {
   zoxide.enable = true;
   eza.enable = true;
   fzf.enable = true;
+  gum.enable = true;
   fd.enable = true;
   ripgrep.enable = true;
   chrome-cli.enable = true;


### PR DESCRIPTION
`gum write` uses `ctrl+j` to insert a newline, which is hard to remember. This makes `shift+enter` do it instead.

## Why a patch

gum exposes no way to change this: no flag, no `GUM_*` env var, no config file. `write/options.go` in v2.0.0 carries exactly one behavioural flag (`--show-help`). Upstream [#727](https://github.com/charmbracelet/gum/issues/727) (issue) and [#822](https://github.com/charmbracelet/gum/pull/822) (PR) are both still open.

## Why v2 specifically

The version bump is load-bearing, not incidental. nixpkgs ships gum 0.17.0 built on bubbletea **v1.3.6**, which cannot receive `shift+enter` at all — the terminal collapses it to a bare CR, so binding the string would be inert. gum v2.0.0 (released 2026-08-20) moved to bubbletea **v2**, which speaks the kitty keyboard protocol, so `"shift+enter"` became a key string that can actually match.

`ctrl+j` is kept alongside it, so existing muscle memory still works.

## Why tmux changed too

`extended-keys on` only governs what tmux sends *inward* to panes. To receive disambiguated keys from the outer terminal, tmux must also believe that terminal supports them — the `extkeys` feature. Ghostty (`TERM=xterm-ghostty`) matches the stock `xterm*` entry, which lacks `extkeys`, so without this `shift+enter` arrives as a bare CR and the patch looks broken.

## Why an overlay, not just home.packages

`modules/dev/linear.nix` bakes `pkgs.gum` into its script PATH and `modules/cli/todoist.nix` lists it in `runtimeInputs`. Both would otherwise keep pointing at the unpatched 0.17.0 store path.

## Verification

- `shift+enter` inserts a newline; `enter` still submits; `ctrl+j` still works
- `darwinConfigurations.vega.system` builds, with `gum-2.0.0` as the **only** gum in the closure (0.17.0 fully gone)
- `nixfmt --check`, `statix check .`, `nix flake check` all exit 0

The comment in `modules/cli/todoist.nix` that documented `ctrl+j` was updated so it doesn't go stale.
