### PR TITLE
feat(linear): mirror assigned issues into Todoist

### DIFF
--- a/modules/dev/linear/linear.nix
+++ b/modules/dev/linear/linear.nix
@@ -42,6 +42,15 @@ in
 mkUserModule {
   name = "linear";
   casks = [ "linear" ];
+
+  parts = {
+    # Lives here rather than beside the todoist module because linear-cli is a
+    # private derivation of this let-block, and the launchd agent needs its
+    # store path. It also matches the repo rule that the module which knows how
+    # owns the glue: Linear is what knows which issues are yours.
+    todoist-mirror = import ./todoist-mirror.nix { inherit pkgs lib linear-cli; };
+  };
+
   home =
     { userCfg, ... }:
     {

--- a/modules/dev/linear/todoist-mirror-test.sh
+++ b/modules/dev/linear/todoist-mirror-test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Fixture test for the set logic in todoist-mirror.nix.
+#
+# The mirror's add path is self-evident the first time you run it: everything
+# shows up. The close path is not — it only fires once something has already
+# been mirrored, so the first real run exercises none of it, and it is the only
+# half that can destroy something. This pins it against fixtures instead.
+#
+# Pure jq/comm, no network, no Todoist, no Linear. Run by hand after touching
+# the jq filters:
+#
+#   bash modules/dev/linear/todoist-mirror-test.sh
+#
+# Keep the filters here identical to the ones in todoist-mirror.nix.
+set -euo pipefail
+
+unwrap='(if type == "array" then . else (.results // []) end)'
+
+pass=0
+fail=0
+
+check() {
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %s\n' "$1"
+    pass=$((pass + 1))
+  else
+    printf '  FAIL %s\n       want: [%s]\n       got:  [%s]\n' "$1" "$3" "$2"
+    fail=$((fail + 1))
+  fi
+}
+
+# ENG-1 is still open, ENG-2 is new, ENG-3 has left the open list -> must close.
+linear='[
+  {"identifier":"ENG-1","title":"stays","priority":2},
+  {"identifier":"ENG-2","title":"is new","priority":0}
+]'
+
+# t9 is a hand-written personal task and must be untouchable.
+# t7 looks mirrored but lives in another project, so it is out of scope.
+todoist='{"results":[
+  {"id":"t1","content":"ENG-1 stays","projectId":"P"},
+  {"id":"t3","content":"ENG-3 gone","projectId":"P"},
+  {"id":"t9","content":"buy oat milk","projectId":"P"},
+  {"id":"t7","content":"ENG-9 other project","projectId":"OTHER"}
+]}'
+pid=P
+
+open=$(jq -r '.[].identifier' <<<"$linear" | sort -u)
+mirrored=$(jq -r --arg p "$pid" \
+  "$unwrap"' | map(select(.projectId == $p)) | .[].content' <<<"$todoist" |
+  grep -oE '^[A-Z]+-[0-9]+' | sort -u || true)
+
+flatten() { tr '\n' ' ' | sed 's/^ *//; s/ *$//'; }
+
+adds=$(comm -23 <(printf '%s\n' "$open") <(printf '%s\n' "$mirrored") | flatten)
+closes=$(comm -13 <(printf '%s\n' "$open") <(printf '%s\n' "$mirrored") | flatten)
+
+check "adds only the new issue" "$adds" "ENG-2"
+check "closes the issue no longer open" "$closes" "ENG-3"
+
+# The close path has to resolve a real task id, scoped to the project.
+tid=$(jq -r --arg i "ENG-3" --arg p "$pid" \
+  "$unwrap"' | map(select(.projectId == $p and (.content | startswith($i + " ")))) | .[0].id // empty' \
+  <<<"$todoist")
+check "close resolves the right task id" "$tid" "t3"
+
+# The two safety rails: a personal task is never mirrored, and neither is a
+# mirrored-looking task sitting in some other project.
+check "personal task not seen as mirrored" \
+  "$(printf '%s' "$mirrored" | grep -c 'buy' || true)" "0"
+check "other project excluded" \
+  "$(printf '%s' "$mirrored" | grep -c 'ENG-9' || true)" "0"
+
+# First run: nothing mirrored yet, so everything adds and NOTHING closes.
+m0=$(jq -r --arg p "$pid" "$unwrap"' | map(select(.projectId == $p)) | .[].content' \
+  <<<'{"results":[]}' | grep -oE '^[A-Z]+-[0-9]+' | sort -u || true)
+check "first run closes nothing" \
+  "$(comm -13 <(printf '%s\n' "$open") <(printf '%s\n' "$m0") | flatten)" ""
+check "first run adds everything" \
+  "$(comm -23 <(printf '%s\n' "$open") <(printf '%s\n' "$m0") | flatten)" "ENG-1 ENG-2"
+
+# Linear reachable but empty (everything genuinely done): close the mirrored
+# tasks, and only those.
+o2=$(jq -r '.[].identifier' <<<'[]' | sort -u)
+check "empty Linear closes mirrored only" \
+  "$(comm -13 <(printf '%s\n' "$o2") <(printf '%s\n' "$mirrored") | flatten)" "ENG-1 ENG-3"
+
+# Linear 1..4 is Urgent..Low and maps onto Todoist p1..p4; 0 means "no
+# priority" there and must be omitted rather than flattened into p4.
+while read -r lin_priority want; do
+  [ -n "$lin_priority" ] || continue
+  got=$(jq -r '(.priority // 0) | if . >= 1 and . <= 4 then "p\(.)" else "" end' \
+    <<<"{\"priority\":$lin_priority}")
+  check "priority $lin_priority maps correctly" "$got" "$want"
+done <<'EOF'
+1 p1
+2 p2
+3 p3
+4 p4
+0
+EOF
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/modules/dev/linear/todoist-mirror.nix
+++ b/modules/dev/linear/todoist-mirror.nix
@@ -1,0 +1,238 @@
+# Mirror the Linear issues on your plate into Todoist, one way.
+#
+# This reads Linear's *state*, never its creation events. An issue put there by
+# `lin ai`, by Linear's own AI, from the web app, or from Slack all look
+# identical from here, because the only question asked is "what is assigned to
+# me and not closed". Hooking a creation path instead — `lin create`, `wtl` —
+# would mirror only the issues that happened to be born in a terminal, which is
+# the subset that needs Todoist least.
+#
+# The identifier is the join key and it lives in the task content
+# ("ENG-123 Fix input sizing"), which makes Todoist its own state store. No
+# mapping file to drift out of sync with reality, nothing to rebuild when it
+# does, and a task you reworded on the phone still matches as long as the
+# prefix survives.
+#
+# Direction is Linear -> Todoist only. Completing the task in Todoist does not
+# touch Linear; the next run notices Linear still has it open and puts it back.
+# Closing the loop the other way is a genuinely different feature — it needs to
+# tell "I finished this" apart from "I tidied my list" — and is not this.
+#
+# The close path is the only half that can destroy something, and the first real
+# run exercises none of it (nothing is mirrored yet). ./todoist-mirror-test.sh
+# pins that logic against fixtures — run it after touching the jq filters.
+{
+  pkgs,
+  lib,
+  linear-cli,
+}:
+let
+  # Todoist API v1 answers { results, next_cursor }, but the CLI may already
+  # have unwrapped it. Written as an explicit type test rather than
+  # `.results // .`: indexing an ARRAY with a string key is a jq error, not a
+  # null, so the shorthand makes a bare-array response fail outright. Same
+  # reasoning, same shapes as modules/cli/todoist.nix.
+  unwrap = ''(if type == "array" then . else (.results // []) end)'';
+  wellFormed = ''type == "array" or (type == "object" and has("results"))'';
+
+  # td is a homebrew binary and writeShellApplication resets PATH to
+  # runtimeInputs only — without this the sync silently finds no `td`.
+  brewBin = "/opt/homebrew/bin";
+
+  mirror = pkgs.writeShellApplication {
+    name = "linear-todoist-mirror";
+    runtimeInputs = with pkgs; [
+      jq
+      coreutils
+      gnugrep
+      linear-cli
+    ];
+    text = ''
+      PATH="${brewBin}:''${PATH}"
+
+      dry=0
+      project="Inbox"
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --dry-run) dry=1 ;;
+          --project) project="''${2:-}"; shift ;;
+          -h|--help)
+            echo "usage: linear-todoist-mirror [--dry-run] [--project NAME]"
+            exit 0
+            ;;
+          *) echo "linear-todoist-mirror: unknown argument: $1" >&2; exit 2 ;;
+        esac
+        shift
+      done
+
+      # `lin list` resolves the display name first; the literal string "me" is
+      # not a valid --assignee and silently returns an empty list, which this
+      # script would otherwise read as "nothing is assigned to you".
+      me=$(linear-cli whoami --output json --no-pager --quiet 2>/dev/null | jq -r '.name // empty')
+      if [ -z "$me" ]; then
+        echo "linear-todoist-mirror: not authenticated to Linear" >&2
+        exit 1
+      fi
+
+      # Linear is the only source of truth here, so anything that is not a JSON
+      # array has to stop the run. Read as "nothing assigned", a failed fetch
+      # would close every mirrored task in Todoist — the one irreversible thing
+      # this script can do.
+      if ! linear=$(linear-cli i list --assignee "$me" \
+            --filter "state.name!=Done" \
+            --filter "state.name!=Canceled" \
+            --filter "state.name!=Duplicate" \
+            --output json --no-pager --quiet 2>/dev/null); then
+        echo "linear-todoist-mirror: could not reach Linear" >&2
+        exit 1
+      fi
+      if ! jq -e 'type == "array"' <<<"$linear" >/dev/null 2>&1; then
+        echo "linear-todoist-mirror: unexpected Linear response, refusing to sync" >&2
+        exit 1
+      fi
+
+      if ! todoist=$(td task list --json --limit 300 2>/dev/null); then
+        echo "linear-todoist-mirror: could not reach Todoist — try 'td auth status'" >&2
+        exit 1
+      fi
+      if ! jq -e '${wellFormed}' <<<"$todoist" >/dev/null 2>&1; then
+        echo "linear-todoist-mirror: unexpected Todoist response, refusing to sync" >&2
+        exit 1
+      fi
+
+      # Second fence behind the identifier prefix: only tasks living in the
+      # target project are ever considered mirrored, so a personal task can not
+      # be closed by this even if you name it like an issue. When the project
+      # can not be resolved the prefix is the only rail left, which is why an
+      # unresolvable name is a hard stop rather than a fallback to Inbox.
+      pid=$(td project list --json 2>/dev/null \
+            | jq -r --arg n "$project" '${unwrap} | map(select(.name == $n)) | .[0].id // empty')
+      if [ -z "$pid" ]; then
+        echo "linear-todoist-mirror: no Todoist project named '$project'" >&2
+        exit 1
+      fi
+
+      # One extra query rather than a hardcoded slug or a per-issue `i get`:
+      # `i list` does not return .url, and the workspace never changes mid-run.
+      workspace=$(linear-cli api query '{ organization { urlKey } }' \
+                  --output json --no-pager --quiet 2>/dev/null \
+                  | jq -r '.data.organization.urlKey // empty')
+
+      open=$(jq -r '.[].identifier' <<<"$linear" | sort -u)
+      # grep exits 1 on no match, which is the ordinary first-run state, so the
+      # pipeline must not be allowed to kill the script under pipefail.
+      mirrored=$(jq -r --arg p "$pid" \
+                 '${unwrap} | map(select(.projectId == $p)) | .[].content' <<<"$todoist" \
+                 | grep -oE '^[A-Z]+-[0-9]+' | sort -u || true)
+
+      added=0
+      skipped=0
+      # Heredocs rather than pipes: a piped `while` runs in a subshell and the
+      # counters would not survive the loop.
+      while read -r id; do
+        [ -n "$id" ] || continue
+        row=$(jq -c --arg i "$id" 'map(select(.identifier == $i)) | .[0] // empty' <<<"$linear")
+        [ -n "$row" ] || continue
+
+        title=$(jq -r '.title // ""' <<<"$row")
+        # Linear 1..4 is Urgent..Low and maps straight onto Todoist p1..p4.
+        # 0 means "no priority" there and has no Todoist equivalent, so it is
+        # left off rather than flattened into p4.
+        prio=$(jq -r '(.priority // 0) | if . >= 1 and . <= 4 then "p\(.)" else "" end' <<<"$row")
+
+        args=("$id $title" --project "$project")
+        [ -n "$prio" ] && args+=(--priority "$prio")
+        [ -n "$workspace" ] && args+=(--description "https://linear.app/$workspace/issue/$id")
+
+        if [ "$dry" -eq 1 ]; then
+          printf '  + %s  %s\n' "$id" "$title"
+        elif ! td task add "''${args[@]}" >/dev/null 2>&1; then
+          # Loudly, and without aborting: one malformed title should not stop
+          # the other thirteen issues from landing.
+          printf 'linear-todoist-mirror: failed to add %s\n' "$id" >&2
+          skipped=$((skipped + 1))
+          continue
+        fi
+        added=$((added + 1))
+      done <<EOF
+      $(comm -23 <(printf '%s\n' "$open") <(printf '%s\n' "$mirrored"))
+      EOF
+
+      closed=0
+      while read -r id; do
+        [ -n "$id" ] || continue
+        tid=$(jq -r --arg i "$id" --arg p "$pid" \
+              '${unwrap} | map(select(.projectId == $p and (.content | startswith($i + " ")))) | .[0].id // empty' \
+              <<<"$todoist")
+        [ -n "$tid" ] || continue
+
+        if [ "$dry" -eq 1 ]; then
+          printf '  - %s\n' "$id"
+        elif ! td task complete "id:$tid" --quiet >/dev/null 2>&1; then
+          printf 'linear-todoist-mirror: failed to close %s\n' "$id" >&2
+          continue
+        fi
+        closed=$((closed + 1))
+      done <<EOF
+      $(comm -13 <(printf '%s\n' "$open") <(printf '%s\n' "$mirrored"))
+      EOF
+
+      n=$(jq -r 'length' <<<"$linear")
+      if [ "$dry" -eq 1 ]; then
+        printf 'dry run: %d to add, %d to close (%d open in Linear)\n' "$added" "$closed" "$n"
+      else
+        printf '%s  linear→todoist: %d added, %d closed (%d open)\n' \
+          "$(date '+%Y-%m-%d %H:%M:%S')" "$added" "$closed" "$n"
+        [ "$skipped" -eq 0 ] || printf 'linear-todoist-mirror: %d failed to add\n' "$skipped" >&2
+      fi
+    '';
+  };
+in
+{
+  # Opt-in. The mirror writes to a task list a human reads every day, so it
+  # should never switch itself on as a side effect of enabling the Linear CLI.
+  default = false;
+
+  extraOptions = {
+    project = lib.mkOption {
+      type = lib.types.str;
+      default = "Inbox";
+      description = "Todoist project the mirrored Linear issues live in.";
+    };
+
+    intervalSeconds = lib.mkOption {
+      type = lib.types.int;
+      default = 900;
+      description = "Seconds between mirror runs.";
+    };
+  };
+
+  # No forPlatform guard: linear-cli's own derivation throws on anything that
+  # is not aarch64-darwin, so this module is already darwin-only upstream of
+  # here and a platform split would be dead code.
+  home =
+    { cfg, ... }:
+    {
+      home.packages = [ mirror ];
+
+      launchd.agents.linear-todoist-mirror = {
+        enable = true;
+        config = {
+          Label = "dev.linear.todoist-mirror";
+          ProgramArguments = [
+            "${mirror}/bin/linear-todoist-mirror"
+            "--project"
+            cfg.project
+          ];
+          # ponytail: deliberately not RunAtLoad. The first run after a rebuild
+          # is the one worth watching, so the interval doubles as a window to
+          # run it by hand with --dry-run first. Flip this on once the mirror
+          # has been boring for a while.
+          RunAtLoad = false;
+          StartInterval = cfg.intervalSeconds;
+          StandardOutPath = "/tmp/linear-todoist-mirror.log";
+          StandardErrorPath = "/tmp/linear-todoist-mirror.log";
+        };
+      };
+    };
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -48,7 +48,16 @@ mkUser {
   # rtk.enable = true;
   ollama.enable = true;
   # hermes.enable = true;
-  linear.enable = true;
+  linear = {
+    enable = true;
+    # One-way mirror of the Linear issues assigned to me into the Todoist
+    # project I already keep work in. Reads Linear's state, so it is blind to
+    # how an issue was created.
+    todoist-mirror = {
+      enable = true;
+      project = "Telepatia";
+    };
+  };
 
   # Editors
   nvim.enable = true;


### PR DESCRIPTION
Mirrors the Linear issues assigned to me into the Todoist project I already keep work in, one way.

## Why it reads state, not events

The mirror asks Linear one question — *what is assigned to me and not closed* — so an issue created by `lin ai`, by Linear's own AI, from the web app or from Slack all look identical to it. Hooking a creation path (`lin create`, `wtl`) would have mirrored only the issues that happened to be born in a terminal, which is the subset that needs Todoist least.

## No mapping file

The identifier lives in the task content (`ENG-123 Fix input sizing`), which makes Todoist its own state store. Nothing to drift out of sync, nothing to rebuild when it does, and a task reworded on the phone still matches as long as the prefix survives.

## Direction

Linear → Todoist only. Completing in Todoist does not touch Linear; the next run sees the issue still open and puts it back. Closing that loop needs to tell "I finished this" apart from "I tidied my list" — a different feature, not this one.

## Safety

Adding is harmless; closing is not, and the first real run exercises none of the closing logic. Two rails:

- A failed or malformed Linear fetch **exits** rather than reading as an empty list. Read as "nothing assigned", it would close every mirrored task.
- Only tasks that both match `^[A-Z]+-[0-9]+ ` **and** live in the target project are ever considered mirrored, so a hand-written personal task cannot be closed even if named like an issue.

`todoist-mirror-test.sh` pins that set logic against fixtures (13 assertions, no network).

## Shape

Lives as a `parts` sub-feature of the `linear` module rather than beside `todoist`, because `linear-cli` is a private derivation of that module's `let` and the launchd agent needs its store path. `default = false` — it writes to a list a human reads daily, so it should not switch itself on as a side effect of enabling the Linear CLI.

`RunAtLoad = false` is deliberate and carries a `ponytail:` comment: the interval doubles as a window to run `--dry-run` by hand first.

## Verification

| Check | Result |
|---|---|
| `nix flake check` | all checks passed |
| `nixfmt` + `statix check .` | clean |
| shellcheck (module + test) | clean |
| `todoist-mirror-test.sh` | 13/13 |
| `--dry-run` vs real Linear | 14 add, 0 close, 0 writes |