### PR TITLE
chore(cold-turkey-blocker): disable for vega

### DIFF
--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -144,7 +144,7 @@ mkUser {
   "windows-app".enable = true;
   granola.enable = true;
   "wispr-flow".enable = true;
-  "cold-turkey-blocker".enable = true;
+  "cold-turkey-blocker".enable = false;
   selfcontrol.enable = true;
 
   # Networking


### PR DESCRIPTION
Flips `"cold-turkey-blocker".enable` to `false` in `modules/users/vega-fernando.nix`.

Homebrew runs with `onActivation.cleanup = "zap"`, so the next rebuild uninstalls the app and wipes its data.