### PR TITLE
feat(tmux): count PRs opened and reviewed today beside the review queue

### DIFF
--- a/modules/cli/tmux/pr.nix
+++ b/modules/cli/tmux/pr.nix
@@ -107,6 +107,20 @@ let
     text = ''
       CACHE=${cache}
 
+      # Local midnight, rendered as UTC: "today" is the day you are having, not
+      # the one UTC is having — a bare date would roll the counters over at
+      # 21:00 here, which is squarely inside a working evening.
+      # The inner date stamps local midnight with its offset; the outer one
+      # converts that instant to Z. Both steps are needed: `date -u -d "today
+      # 00:00:00"` reads *UTC* midnight and returns a different instant.
+      # Z rather than the offset form because GitHub accepts either, while jq
+      # only compares timestamps correctly when both sides share a shape, and
+      # submittedAt always comes back as Z.
+      # Exported because gh's --jq takes no --arg, and jq's env is the one way
+      # into that program without splicing shell into a quoted jq body.
+      PR_SINCE=$(date -u -d "$(date +%Y-%m-%dT00:00:00%:z)" +%Y-%m-%dT%H:%M:%SZ)
+      export PR_SINCE
+
       # Claim the slot before the ~1s round trip. The widget ticks every 5s and
       # decides staleness by mtime, so without touching first it would spawn a
       # fresh refresh on every tick for the whole duration of this one.
@@ -279,14 +293,41 @@ let
         rm -rf "$work"
       }
 
+      # The $-names inside the quoted bodies below are GraphQL and jq
+      # variables, not shell ones, and single quotes are exactly what keeps
+      # bash out of them.
+      # shellcheck disable=SC2016
       gh api graphql \
+        -f openedQuery="is:pr author:@me created:>=$PR_SINCE" \
+        -f reviewedQuery="is:pr reviewed-by:@me updated:>=$PR_SINCE" \
         -f query='
-          query {
+          query($openedQuery: String!, $reviewedQuery: String!) {
             review: search(query: "is:open is:pr review-requested:@me archived:false", type: ISSUE, first: 100) {
               nodes { ...pr }
             }
             mine: search(query: "is:open is:pr author:@me archived:false", type: ISSUE, first: 100) {
               nodes { ...pr }
+            }
+            # Deliberately unfiltered by state: a PR you opened and merged
+            # before lunch still happened. `mine` cannot answer this — it is
+            # is:open, and the whole point of a good day is that they close.
+            # The date lives in a variable because the query is a single-quoted
+            # nix/shell string, so nothing interpolates into it in place.
+            openedToday: search(query: $openedQuery, type: ISSUE, first: 1) {
+              issueCount
+            }
+            # GitHub has no "reviewed on" qualifier, so the search is only the
+            # candidate net: submitting a review bumps that updatedAt past
+            # local midnight, which makes updated:>= a superset of the answer.
+            # viewerLatestReview.submittedAt is the actual cut — the same field
+            # the queue above already trusts, and null while a review is still
+            # an unsubmitted draft, which correctly scores as not reviewed yet.
+            reviewedToday: search(query: $reviewedQuery, type: ISSUE, first: 100) {
+              nodes {
+                ... on PullRequest {
+                  viewerLatestReview { submittedAt }
+                }
+              }
             }
           }
           fragment pr on PullRequest {
@@ -370,9 +411,22 @@ let
           def awaiting_me:
             .viewerLatestReview == null
             or (.viewerLatestReview.state | IN("PENDING", "DISMISSED"));
-          {
+          # Lexical >=, which is a real time comparison only because both sides
+          # are fixed-width UTC Z — what PR_SINCE goes to the trouble of
+          # guaranteeing. Deliberately not fromdate: that builtin parses
+          # %Y-%m-%dT%H:%M:%SZ and nothing else, so the offset form errors out.
+          env.PR_SINCE as $since
+          | {
             review: [ .data.review.nodes[] | select(awaiting_me) | norm ],
-            mine:   [ .data.mine.nodes[]   | norm ]
+            mine:   [ .data.mine.nodes[]   | norm ],
+            today: {
+              opened: .data.openedToday.issueCount,
+              reviewed: [
+                .data.reviewedToday.nodes[]
+                | .viewerLatestReview.submittedAt
+                | select(. != null and . >= $since)
+              ] | length
+            }
           }' >"$tmp" 2>/dev/null
 
       # Only publish a well-formed, non-empty result. A network blip or an
@@ -556,6 +610,10 @@ let
       # Flexoki light theme colors (same palette as the cpu/disk widgets)
       BG="#f2f0e5"
       FG="#100f0f"
+      # Flexoki base-600. The queue is a thing to act on and the day's tallies
+      # are a thing to notice, so they must not compete: same row, half the
+      # contrast, no bold.
+      MUTED="#6f6e69"
 
       RESET="#[fg=''${FG},bg=''${BG},nobold,noitalics,nounderscore,nodim]"
 
@@ -585,15 +643,49 @@ let
 
       case "''${n:-}" in "" | *[!0-9]*) exit 0 ;; esac
 
+      # Today's tallies, written by the same refresh that filled the queue: no
+      # second poll, no second cache, and they go stale on the same 2-minute
+      # mtime check. Defaulted rather than required, because a cache written by
+      # the previous build of this widget has no .today at all and one rebuild
+      # should not blank the segment until the next refresh lands.
+      read -r opened reviewed <<<"$(jq -r '
+        [(.today.opened // 0), (.today.reviewed // 0)] | @tsv
+      ' "$CACHE" 2>/dev/null)"
+
+      case "''${opened:-}" in "" | *[!0-9]*) opened=0 ;; esac
+      case "''${reviewed:-}" in "" | *[!0-9]*) reviewed=0 ;; esac
+
       # Silent at zero, like the disk widget: an empty queue is not news, and a
       # segment that is always on screen is a segment you stop seeing. Snoozing
       # the last PR therefore clears the slot entirely, which is the point of
       # snoozing it.
-      [ "$n" -gt 0 ] || exit 0
+      #
+      # All-or-nothing, and the three numbers never hide individually: without
+      # a glyph on each one, position is the only thing saying which is which,
+      # and a lone "58 6" cannot be read as queue-plus-reviewed rather than
+      # queue-plus-opened. Hiding a zero would silently shift the survivors one
+      # slot left and quietly change what the row means. So the zeros stay as
+      # placeholders, and only an entirely empty day clears the segment.
+      if [ "$n" -eq 0 ] && [ "$opened" -eq 0 ] && [ "$reviewed" -eq 0 ]; then
+        exit 0
+      fi
 
-      # Black rather than a threshold colour: this is a thing you scan for on
-      # purpose, not an alarm that should compete with cpu and disk.
-      echo "#[fg=''${FG},bg=''${BG},bold] ''${GH} ''${n}''${RESET} "
+      # One leading and one trailing space for the whole block, single spaces
+      # inside it. Every widget here pads itself on both sides, so the gap
+      # between two widgets is always two — padding each number that way made
+      # them read as three unrelated segments, indistinguishable from todoist
+      # and cpu sitting beside them.
+      #
+      # Slash-joined rather than space-joined, which costs the same width and
+      # buys the grouping: on a row where every other widget is also an icon
+      # followed by a number, three space-separated numbers read as three
+      # widgets. 58/1/6 reads as one compound value, which is what it is.
+      #
+      # Only the queue is black and bold: it is the number you act on, and the
+      # icon marks the block as PRs so three bare numbers are not stranded next
+      # to the todoist count. The tallies stay muted, a thing to notice — the
+      # style switches at the first slash so the separators travel with them.
+      echo "#[fg=''${FG},bg=''${BG},bold] ''${GH} ''${n}#[fg=''${MUTED},bg=''${BG},nobold]/''${opened}/''${reviewed}''${RESET} "
     '';
   };
 

--- a/modules/cli/tmux/pr.test.sh
+++ b/modules/cli/tmux/pr.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Self-check for the PR widget's status segment. Builds the real derivation out
+# of pr.nix (so it cannot drift from the source the way a transcribed copy
+# would) and drives it with fixture caches.
+#
+# Worth testing because the numbers carry no labels: only their position says
+# which is the review queue, which is opened-today and which is reviewed-today.
+# A change that lets one of them hide at zero shifts the other two a slot left
+# and silently changes what the row means — it still renders, still looks
+# plausible, and nothing errors. The whole-segment silence at zero has the same
+# property in reverse: it is indistinguishable from a quiet day.
+#
+# Run by hand: bash pr.test.sh
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+SRC="$HERE/pr.nix"
+
+[[ -f "$SRC" ]] || {
+  echo "FAIL: $SRC not found"
+  exit 1
+}
+
+# Built rather than extracted: the widget body is full of Nix interpolations
+# (${cache}, ${jqIgnore}, the refresh store path), and a test that rewrites
+# those by hand is testing its own sed, not the widget. Cheap after the first
+# run — nix serves it from the store. The nixpkgs rev comes from flake.lock so
+# the test builds against the same nixpkgs as a rebuild would, and getFlake on
+# the pinned rev sidesteps `path:` fetching the repo (which trips over
+# .git/fsmonitor--daemon.ipc, an unsupported file type).
+REV=$(jq -r '.nodes[.nodes.root.inputs.nixpkgs].locked.rev' "$REPO/flake.lock")
+WIDGET=$(nix build --impure --no-link --print-out-paths --expr "
+  let
+    pkgs = (builtins.getFlake \"github:NixOS/nixpkgs/$REV\").legacyPackages.aarch64-darwin;
+    mod = import $SRC { inherit pkgs; };
+  in
+  builtins.elemAt mod.home.home.packages 1
+" 2>/dev/null)
+
+[[ -n "$WIDGET" && -x "$WIDGET/bin/tmux-pr-widget" ]] || {
+  echo "FAIL: could not build tmux-pr-widget from $SRC"
+  exit 1
+}
+
+GH=$'\uF09B' # nf-fa-github — marks the block; the numbers themselves are bare
+
+fail=0
+
+# Run the widget against a fixture cache. HOME is redirected so the widget reads
+# an empty snooze list instead of the real one — otherwise a genuinely snoozed
+# fixture URL would silently drop a row and read as a rendering bug. TMPDIR
+# places the cache where ${cache} expects it, and writing it now keeps its mtime
+# inside the 2-minute freshness window, so no background refresh is spawned and
+# the test never touches the network.
+run_with() {
+  local cache_json=$1 out sandbox
+  sandbox=$(mktemp -d)
+  printf '%s' "$cache_json" >"$sandbox/tmux-pr.json"
+  out=$(HOME="$sandbox" TMPDIR="$sandbox" "$WIDGET/bin/tmux-pr-widget" 2>/dev/null || true)
+  rm -rf "$sandbox"
+  # Strip tmux style directives; only the icon, numbers and spacing are tested.
+  printf '%s' "$out" | sed 's/#\[[^]]*\]//g'
+}
+
+# $1 label, $2 cache, $3 expected (after style stripping)
+expect() {
+  local label=$1 got
+  got=$(run_with "$2")
+  if [[ "$got" != "$3" ]]; then
+    printf 'FAIL: %s\n  expected: %q\n  got:      %q\n' "$label" "$3" "$got"
+    fail=1
+  else
+    printf 'ok: %s\n' "$label"
+  fi
+}
+
+# One un-snoozed, non-context PR is one unit of queue.
+pr='{"url":"https://example.test/pr/1","updated":"2026-01-01T00:00:00Z","context":false}'
+pr2='{"url":"https://example.test/pr/2","updated":"2026-01-01T00:00:00Z","context":false}'
+
+expect "silent only when the queue and both tallies are zero" \
+  '{"review":[],"mine":[],"today":{"opened":0,"reviewed":0}}' \
+  ''
+
+# The order is queue, opened, reviewed, and it is the only thing distinguishing
+# them now that the numbers are unlabelled. The slashes bind them into one
+# value so the row does not read as three separate widgets.
+expect "queue, then opened, then reviewed, slash-joined" \
+  "{\"review\":[$pr],\"mine\":[],\"today\":{\"opened\":3,\"reviewed\":7}}" \
+  " ${GH} 1/3/7 "
+
+# Each of the next three pins one slot at zero. Together they are the real
+# regression net: any of them collapsing to a two-number row means a reader can
+# no longer tell which number they are looking at.
+expect "a zero queue still holds its slot" \
+  '{"review":[],"mine":[],"today":{"opened":2,"reviewed":5}}' \
+  " ${GH} 0/2/5 "
+
+expect "a zero opened still holds its slot" \
+  "{\"review\":[$pr,$pr2],\"mine\":[],\"today\":{\"opened\":0,\"reviewed\":5}}" \
+  " ${GH} 2/0/5 "
+
+expect "a zero reviewed still holds its slot" \
+  "{\"review\":[$pr],\"mine\":[],\"today\":{\"opened\":4,\"reviewed\":0}}" \
+  " ${GH} 1/4/0 "
+
+# A cache written by the previous build survives one rebuild without .today.
+# It must degrade to zeroed tallies, not to an empty status bar.
+expect "cache with no today key zeroes the tallies" \
+  "{\"review\":[$pr],\"mine\":[]}" \
+  " ${GH} 1/0/0 "
+
+# A context parent is a tree-readability row, never assigned to you.
+expect "context parents stay out of the queue count" \
+  '{"review":[{"url":"https://example.test/pr/9","updated":"2026-01-01T00:00:00Z","context":true}],"mine":[],"today":{"opened":0,"reviewed":0}}' \
+  ''
+
+if ((fail)); then
+  echo "FAILED"
+  exit 1
+fi
+echo "All PR widget checks passed."


### PR DESCRIPTION
The PR status segment showed one number — the review queue — which is a debt.
A debt-only readout has nothing to say about a day where the queue stayed flat
because you spent it reviewing. Two tallies now sit beside it, as one
slash-joined value:

```
  2    58/1/6   8   16%
         └ queue / opened today / reviewed today
```

30 columns, same as before the tallies existed plus 4.

## Where the numbers come from

Both ride along in the GraphQL round trip that already fills the queue — no
second poll, no second cache, no launchd agent, and they go stale on the same
2-minute mtime check the widget already runs. One point each of the 5000/hr
budget.

**Opened** is state-blind on purpose. The `mine` list already in the cache is
`is:open`, so it cannot answer this: a PR opened and merged before lunch still
happened, and in this repo most of them do.

**Reviewed** cuts on `viewerLatestReview.submittedAt`, not on the search.
GitHub has no reviewed-on qualifier, so `reviewed-by:@me updated:>=` is only
the candidate net — submitting a review bumps `updatedAt` past midnight, which
makes it a superset of the answer. Using it directly would have counted a PR
reviewed last week that someone commented on today. `submittedAt` is null while
a review is an unsubmitted draft, which correctly scores as not reviewed yet.

**Today** is local midnight expressed as UTC. A bare date rolls the counters
over at 21:00 here, squarely inside a working evening. `date -u -d "today
00:00:00"` reads *UTC* midnight and returns a different instant, so the
boundary is built in two steps — stamp local midnight with its offset, then
convert. Z rather than the offset form because jq compares timestamps correctly
only when both sides share a shape, and `submittedAt` always comes back as Z.

## Why nothing hides at zero

The three numbers are unlabelled, so position is the only thing saying which is
which. If a zero could hide, the survivors would shift a slot left and `58/6`
would be unreadable — 6 opened, or 6 reviewed? So the zeros stay as
placeholders and only an entirely empty day clears the segment.

That is the failure mode worth guarding, because it renders fine and reads
wrong. Three of the seven checks in the new `pr.test.sh` exist only to pin each
slot at zero. The test builds the real derivation out of `pr.nix` rather than
transcribing the widget body, so it cannot drift.

## Verification

- `nixfmt`, `statix`, `shellcheck` clean
- 7/7 checks in `modules/cli/tmux/pr.test.sh`
- End to end against the live account: `today.opened` matched the one PR
  authored that day, `today.reviewed` matched the six PRs whose latest review
  by me was submitted after local midnight
