### PR TITLE
feat(hammerspoon): spend hyper+T on tasks instead of a new terminal window

### DIFF
--- a/modules/darwin/hammerspoon/init.lua
+++ b/modules/darwin/hammerspoon/init.lua
@@ -189,27 +189,26 @@ local function warpToApp(bundleID, screen, tries)
   end
 end
 
--- Hyper + T → Open a new Ghostty window in the ALREADY-RUNNING instance.
--- This used to shell out to `open -na Ghostty`, but -n means "new instance":
--- every press forked another Ghostty process, so AltTab filled with duplicate
--- windows that no amount of quitting one window would clear. The File → New
--- Window menu item is the supported way to add a window here — ghostty's own
--- `+new-window` action is GTK-only and exits with "not supported on this
--- platform" on macOS.
+-- Hyper + T → Todoist triage popup (mnemonic: Tasks). Same picker as `t` in a
+-- pane and prefix+t in tmux, so the reflex is one key everywhere. This used to
+-- open a new Ghostty window; hyper+space already reaches the terminal, so the
+-- key was spent on a thing that never got pressed. Ghostty is surfaced because
+-- the popup renders inside the tmux client, which has to be visible to matter.
+-- The popup command runs with the tmux SERVER's environment, which has no
+-- ~/.nix-profile/bin — a bare `tmux-todoist-pick` is not found, and -E closes
+-- the popup the instant it exits. Hence the full path (the in-tmux binding
+-- uses the nix store path for the same reason; this file can't interpolate).
+-- ponytail: no fallback when tmux isn't running; add one if that ever happens.
 local tCode = hs.keycodes.map["t"]
 if tCode then
   keyCodeNames[tCode] = "t"
   hyperActionsByKeyCode[tCode] = function()
-    local ghostty = hs.application.get("com.mitchellh.ghostty")
-    if ghostty then
-      -- Activate first: selectMenuItem drives the AX menu bar, which is only
-      -- reliably populated for the frontmost app.
-      ghostty:activate()
-      ghostty:selectMenuItem({ "File", "New Window" })
-    else
-      hs.application.launchOrFocusByBundleID("com.mitchellh.ghostty")
-    end
+    hs.application.launchOrFocusByBundleID("com.mitchellh.ghostty")
     warpToApp("com.mitchellh.ghostty")
+    hs.task.new("/bin/sh", nil, {
+      "-l", "-c",
+      'tmux display-popup -E -w 80% -h 60% "$HOME/.nix-profile/bin/tmux-todoist-pick"',
+    }):start()
   end
 end
 


### PR DESCRIPTION
Hyper+T opened a new Ghostty window, which is a thing that never got pressed:
hyper+space already reaches the terminal, and once you are there tmux makes
windows for free. So the cheapest key on the layer was paying for a shortcut
to something two other reflexes already covered.

It opens the Todoist picker now — the same one `t` opens in a pane and
prefix+t opens in tmux. That makes the picker one key from everywhere rather
than one key from inside the terminal, which is where triage actually needs to
be: the moment a task occurs to you is rarely the moment you are in tmux.

Ghostty is surfaced first because the popup renders inside the tmux client,
so the client has to be on screen for the popup to mean anything.

The path is spelled out in full. `tmux display-popup` runs its command with
the tmux SERVER's environment, whose PATH is the store tmux plus /usr/bin and
/bin — no ~/.nix-profile/bin. A bare `tmux-todoist-pick` is therefore not
found, and -E closes the popup the instant the command exits, so the first
version of this opened and shut a popup with nothing in it. The in-tmux bind
sidesteps the same trap by interpolating the nix store path; init.lua is
copied verbatim and cannot interpolate, so it goes through the profile
symlink, which home-manager keeps pointed at whatever the current store path
is.

Nothing covers tmux not running at all. Hyper+T is a no-op then, marked in
place, and the fix is a fallback nobody has needed yet.
