### PR TITLE
fix(openclaw): drop the dead garnix binary cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,8 +118,8 @@
     # Deliberately NOT following our nixpkgs, and this is load-bearing: openclaw
     # refuses to start on node < 22.22.3, their pin carries nodejs_22 = 22.23.1
     # and ours carries 22.22.2. Building it against our nixpkgs yields a gateway
-    # that exits 1 and crash-loops under launchd. Their pin is also what upstream
-    # publishes to cache.garnix.io. Cost is a second nixpkgs in the lock.
+    # that exits 1 and crash-loops under launchd. Cost is a second nixpkgs in
+    # the lock.
     nix-openclaw = {
       url = "github:openclaw/nix-openclaw";
     };

--- a/modules/dev/openclaw.nix
+++ b/modules/dev/openclaw.nix
@@ -11,9 +11,7 @@ let
   # Applying the overlay to OUR nixpkgs instead (the obvious move) rebuilds
   # openclaw against our nodejs_22 = 22.22.2 — one patch below the >=22.22.3
   # floor openclaw enforces at startup — so the gateway exits 1 and launchd
-  # crash-loops it. Their pin carries nodejs_22 = 22.23.1 deliberately. It also
-  # costs the binary cache: garnix publishes builds made against their pin, so
-  # rebuilding against ours misses every substitute.
+  # crash-loops it. Their pin carries nodejs_22 = 22.23.1 deliberately.
   openclawPkgs = import inputs.nix-openclaw.inputs.nixpkgs {
     inherit system;
     overlays = [ inputs.nix-openclaw.overlays.default ];
@@ -42,16 +40,13 @@ mkUserModule {
       })
     ];
 
-    # Pre-built openclaw. The flake declares this cache in its own nixConfig,
-    # but flake nixConfig does not apply to inputs — without it here, every
-    # rebuild compiles a pnpm workspace with native addons (sharp, node-pty)
-    # from source. Upstream publishes packages.aarch64-darwin.openclaw here.
-    nix.settings = {
-      extra-substituters = [ "https://cache.garnix.io" ];
-      extra-trusted-public-keys = [
-        "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
-      ];
-    };
+    # No binary cache for openclaw: it built on garnix, and garnix shut its
+    # hosted service down on 2026-07-15 (open-sourced as garnix-io/garnix-ci),
+    # then dropped cache.garnix.io from DNS on 2026-08-17. Declaring a dead
+    # substituter only bought ~4s of retry backoff per nix run. So every hash
+    # bump now compiles a pnpm workspace with native addons (sharp, node-pty)
+    # from source. nix-openclaw's own nixConfig still points at the dead host,
+    # but flake nixConfig does not apply to inputs, so it costs us nothing.
   };
 
   home = {


### PR DESCRIPTION
Every nix run on this machine spent about four and a half seconds failing to resolve `cache.garnix.io` — five retries with backoff, 284ms through 2131ms — before falling through to `cache.nixos.org`. Not an error: nix treats an unreachable substituter as non-fatal, so rebuilds worked the whole time and this only ever showed up as five lines of warning and a stall.

```
warning: unable to download 'https://cache.garnix.io/nix-cache-info':
Could not resolve host: cache.garnix.io; retrying in 284 ms (attempt 1/5)
...
```

## The host is not coming back

| Date | What happened |
|---|---|
| 2026-05-28 | Garnix announces they are open-sourcing the project and shutting the hosted service down |
| 2026-07-15 | Hosted service ends |
| 2026-08-17 | DNS zone rewritten onto the registrar's nameservers |

Only the apex and `www` survived that rewrite. `cache`, `api`, `docs` and `status` are all NXDOMAIN now — confirmed against the authoritative nameserver (`dns1.registrar-servers.com`), not just a local resolver, so this is not a DNS filter or a transient outage.

The reason it went unnoticed is that everything still *looks* alive: the marketing site answers on the apex and still advertises the cache as a product, the garnix docs still print this exact URL and key, and `nix-openclaw`'s own flake still declares it. That is how a substituter which stopped existing in July was still configured here in August.

## The nixpkgs pin stays

Its comment gave two reasons to hold `nix-openclaw`'s nixpkgs rather than follow ours, and only the second one died:

1. **Still load-bearing** — openclaw refuses to start on node < 22.22.3. Their pin carries `nodejs_22 = 22.23.1`, ours carries `22.22.2`. Building against ours yields a gateway that exits 1 and crash-loops under launchd.
2. **Now void** — their pin was also what upstream published to garnix.

So `openclawPkgs` is untouched; only the stale garnix clause is dropped from the two comments that mentioned it.

openclaw compiles from source on every hash bump now, native addons and all. That has been true since July regardless — declaring the dead host bought the retry delay and nothing else.

## Verification

- `nixfmt` and `statix` clean (pre-commit hooks passed)
- `nix flake check` — exit 0, all checks passed, **zero** garnix mentions
- `sudo darwin-rebuild switch --flake .#vega` — exit 0
- `/etc/nix/nix.conf` no longer lists garnix in `extra-substituters`
- Fresh `darwin-rebuild build` output is three lines with no DNS retries

Worth knowing: the switch that *removed* the substituter still printed the warnings, because nix reads `/etc/nix/nix.conf` at startup and the new one is not written until activation. The run after it is clean.
