### PR TITLE
fix(opencode): stop the edit tool from eating dollar signs

### DIFF
--- a/modules/dev/opencode/opencode.nix
+++ b/modules/dev/opencode/opencode.nix
@@ -14,6 +14,7 @@ let
   opencode-unwrapped = inputs.opencode.packages.${system}.default.overrideAttrs (old: {
     patches = (old.patches or [ ]) ++ [
       ./patches/cursor-style-and-blink.patch
+      ./patches/edit-tool-dollar-substitution.patch
       ./patches/generate-remove-prettier.patch
       ./patches/relax-bun-version-check.patch
     ];

--- a/modules/dev/opencode/patches/edit-tool-dollar-substitution.patch
+++ b/modules/dev/opencode/patches/edit-tool-dollar-substitution.patch
@@ -1,0 +1,71 @@
+Stop the edit tool from mangling `$` sequences in `newString`.
+
+`String.prototype.replace` and `.replaceAll` treat a *string* replacement
+as a pattern, not as literal text.  Even when the search argument is a
+plain string (no regex involved), the replacement is still scanned for
+`$` substitutions:
+
+    $$   inserts a literal `$`          (so `$$` collapses to `$`)
+    $&   inserts the matched substring
+    $`   inserts the text before the match
+    $'   inserts the text after the match
+
+Both edit tools passed the model-supplied `newString` straight in as that
+replacement, so any of those sequences was silently rewritten on write.
+The file ended up with content the model never asked for, no error was
+raised, and the tool reported success — the corruption only surfaced later
+when someone read the file back.
+
+`$$` collapsing to `$` is the common case (shell scripts, Makefiles, jq
+programs, LaTeX, Perl/PHP sigils, `$$` for PID).  `$&` and `` $` `` are
+rarer but far worse: they inject unrelated file content into the middle of
+the edit.
+
+The fix is to pass a *function* replacement.  Per the spec, when the
+replacement is a function its return value is inserted verbatim — the `$`
+scanning only applies to string replacements — so `() => newString` is an
+exact-insert with no other behavioural change.
+
+Two call sites, both reachable depending on which edit tool is registered:
+
+  * packages/core/src/tool/edit.ts — affects BOTH the `replaceAll: true`
+    and the single-replacement path, so ordinary one-shot edits corrupt.
+  * packages/opencode/src/tool/edit.ts — only the `replaceAll: true` path;
+    the single path already builds the result with substring concatenation
+    and was never affected.
+
+Still present on upstream `dev` as of 1.18.10 (7902e04).  Drop this patch
+once upstream inserts the replacement literally.
+
+diff --git a/packages/core/src/tool/edit.ts b/packages/core/src/tool/edit.ts
+--- a/packages/core/src/tool/edit.ts
++++ b/packages/core/src/tool/edit.ts
+@@ -176,10 +176,12 @@ const layer = Layer.effectDiscard(
+                   })
+                 }
+ 
++                // Function replacement: a string one is scanned for dollar-sign
++                // patterns and silently corrupts newString. A function inserts verbatim.
+                 const replaced =
+                   input.replaceAll === true
+-                    ? source.text.replaceAll(oldString, newString)
+-                    : source.text.replace(oldString, newString)
++                    ? source.text.replaceAll(oldString, () => newString)
++                    : source.text.replace(oldString, () => newString)
+                 const counts = diffLines(source.text, replaced).reduce(
+                   (result, item) => ({
+                     additions: result.additions + (item.added ? (item.count ?? 0) : 0),
+diff --git a/packages/opencode/src/tool/edit.ts b/packages/opencode/src/tool/edit.ts
+--- a/packages/opencode/src/tool/edit.ts
++++ b/packages/opencode/src/tool/edit.ts
+@@ -712,7 +712,9 @@ export function replace(content: string, oldString: string, newString: string, r
+         )
+       }
+       if (replaceAll) {
+-        return content.replaceAll(search, newString)
++        // Function replacement: a string one is scanned for dollar-sign
++        // patterns and silently corrupts newString. A function inserts verbatim.
++        return content.replaceAll(search, () => newString)
+       }
+       const lastIndex = content.lastIndexOf(search)
+       if (index !== lastIndex) continue


### PR DESCRIPTION
The edit tool silently rewrote dollar sequences in `newString`. Noticed as `$$` collapsing to `$` across many sessions; it turned out to be broader than that.

## Cause

`String.prototype.replace` and `.replaceAll` treat a *string* replacement as a pattern, even when the search argument is a plain string and no regex is involved. Both edit tools passed the model's `newString` in as that replacement, so it was scanned for:

| sequence | became | effect |
|---|---|---|
| `$$` | `$` | collapsed — the reported symptom |
| `$&` | the matched text | pastes `oldString` back into the edit |
| `` $` `` | text before the match | splices in unrelated file content |
| `$'` | text after the match | splices in unrelated file content |

The write succeeded and the tool reported success, so nothing surfaced at edit time. `$$` is the common case (shell, make, jq, LaTeX, perl/php sigils, `$$` for a pid) and costs one character. `$&` and `` $` `` are rarer and worse: they paste unrelated bytes into the middle of the edit.

## Fix

Pass a function. Dollar substitution only applies to string replacements, so a function's return value is inserted verbatim — `() => newString` changes nothing else about the call.

Three call sites, in two tools that were not equally broken:

- `packages/core/src/tool/edit.ts` — routes **both** the `replaceAll: true` and the single-replacement branch through the string form, so ordinary one-shot edits corrupted. This is the one that was actually firing.
- `packages/opencode/src/tool/edit.ts` — `replaceAll: true` only; the single path already builds its result with substring concatenation and was never affected.

## Verification

Reproduced live against the running binary before the change, with a single non-`replaceAll` edit:

```
in:  single: $$DOLLAR and $& and $`tick
out: single: $DOLLAR and PLACEHOLDER_A and tick
```

Confirmed in the built artifact rather than the source, by diffing minified output old vs new:

```js
// new
replaceAll===!0 ? $.text.replaceAll(C,()=>F) : $.text.replace(C,()=>F)
```

The three arrow-form call sites (`.replaceAll(y,()=>r)`, `.replaceAll(C,()=>F)`, `.replace(C,()=>F)`) are present in the new binary and absent from the previous one. Nothing else in the binary changed shape.

`statix check .` and `nixfmt` pass; `sudo darwin-rebuild switch --flake .#vega` completed.

## Expiry

Still present on upstream `dev` as of 1.18.10 (7902e04), so it stays a patch. If upstream touches those lines the patch stops applying and the nix build fails loudly — no silent rot.
