### PR TITLE
feat(todoist): keep today's list on screen in a pane of its own

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,33 @@
               hostCfg.config.home-manager.users.fernando.xdg.configFile."nvim/init.lua".source
             } /dev/null && touch $out
           '';
+
+        # Hammerspoon's init.lua has the widest blast radius of any Lua here: a
+        # syntax error takes the Caps Lock → Hyper eventtap with it, so the fix
+        # has to be typed on a keyboard whose Caps Lock no longer works. Nix
+        # treats it as opaque text and Hammerspoon only complains in a log file,
+        # which is exactly the combination that ships a broken one.
+        hammerspoonInitCheck =
+          hostName: hostCfg:
+          pkgs.runCommand "hammerspoon-init-lua-${hostName}" { } ''
+            ${pkgs.luajit}/bin/luajit -b ${
+              hostCfg.config.home-manager.users.fernando.home.file.".hammerspoon/init.lua".source
+            } /dev/null && touch $out
+          '';
+
+        # Same blind spot as the nvim check, one layer further: nix cannot see a
+        # Lua error, AND Hammerspoon reports one only in a log nobody reads, so a
+        # broken panel is a panel that silently never appears. This runs the
+        # panel's own assertions against the INSTALLED file — prelude included —
+        # so the generated config header is covered too.
+        todoistPanelCheck =
+          hostName: hostCfg:
+          pkgs.runCommand "todoist-panel-lua-${hostName}" { } ''
+            PANEL=${
+              hostCfg.config.home-manager.users.fernando.home.file.".hammerspoon/extras/todoist-panel.lua".source
+            } \
+              ${pkgs.luajit}/bin/luajit ${./modules/cli/todoist-panel-test.lua} && touch $out
+          '';
       in
       {
         # legacyPackages, not packages: this is the whole nixpkgs set, and
@@ -176,6 +203,8 @@
         checks =
           lib.optionalAttrs (system == "aarch64-darwin") {
             nvim-init-vega = nvimInitCheck "vega" darwinConfigurations.vega;
+            hammerspoon-init-vega = hammerspoonInitCheck "vega" darwinConfigurations.vega;
+            todoist-panel-vega = todoistPanelCheck "vega" darwinConfigurations.vega;
           }
           // lib.optionalAttrs (system == "x86_64-linux") {
             nvim-init-polaris = nvimInitCheck "polaris" nixosConfigurations.polaris;

--- a/modules/cli/todoist-panel-test.lua
+++ b/modules/cli/todoist-panel-test.lua
@@ -1,0 +1,591 @@
+-- Self-check for todoist-panel.lua, run by `nix flake check`.
+--
+-- The panel cannot be exercised on the machine it runs on without a live
+-- Hammerspoon, a live Todoist token and a monitor, so the parts worth
+-- protecting — the TSV parse, the row cap, the show/hide edges and the colour
+-- routing — are driven here against a stub `hs`. Everything below is an assert;
+-- there is no framework and nothing to install.
+--
+-- Locally:  nvim -l modules/cli/todoist-panel-test.lua
+-- In CI:    nix flake check   (runs it under luajit against the INSTALLED file,
+--                              prelude and all, so the nix-generated config
+--                              header is covered too)
+--
+-- Lua 5.1 / luajit compatible on purpose — that is what the flake check uses.
+
+local PANEL = os.getenv("PANEL") or "modules/cli/todoist-panel.lua"
+
+-- ---------------------------------------------------------------------------
+-- Stub hs
+-- ---------------------------------------------------------------------------
+local captured, calls
+
+-- Every frame the panel handed to __hsReclaim, in order.
+local reclaims = {}
+
+local function reset()
+  captured = {}
+  calls = { show = 0, hide = 0, frames = {} }
+  reclaims = {}
+end
+
+local canvas = setmetatable({}, {
+  __index = function(t, k)
+    if k == "level" or k == "behavior" then
+      return function(s)
+        return s
+      end
+    end
+    if k == "show" then
+      return function(s)
+        calls.show = calls.show + 1
+        return s
+      end
+    end
+    if k == "hide" then
+      return function(s)
+        calls.hide = calls.hide + 1
+        return s
+      end
+    end
+    if k == "frame" then
+      return function(s, f)
+        if f then
+          calls.frames[#calls.frames + 1] = f
+          rawset(t, "_f", f)
+          return s
+        end
+        return rawget(t, "_f") or { x = 0, y = 0, w = 300, h = 200 }
+      end
+    end
+    return rawget(t, k)
+  end,
+})
+
+local SCREEN = { x = 0, y = 25, w = 1920, h = 1055 }
+local stdout = ""
+-- Stands in for hs.settings' on-disk store, which is what has to survive the
+-- reload-on-wake that a plain local would not.
+local SETTINGS = {}
+
+local styledMT
+styledMT = {
+  __concat = function(a, b)
+    return setmetatable({ s = (a.s or "") .. (b.s or "") }, styledMT)
+  end,
+}
+
+hs = {
+  canvas = {
+    new = function()
+      return canvas
+    end,
+    windowLevels = { floating = 5 },
+  },
+  styledtext = {
+    new = function(s, attrs)
+      local o = setmetatable({
+        s = s,
+        color = attrs and attrs.color,
+        font = attrs and attrs.font,
+      }, styledMT)
+      captured[#captured + 1] = o
+      return o
+    end,
+  },
+  alert = {
+    show = function() end,
+  },
+  keycodes = { map = { p = 35 } },
+  settings = {
+    get = function(k)
+      return SETTINGS[k]
+    end,
+    set = function(k, v)
+      SETTINGS[k] = v
+    end,
+  },
+  screen = {
+    find = function()
+      return nil
+    end,
+    primaryScreen = function()
+      return {
+        frame = function()
+          return SCREEN
+        end,
+        getUUID = function()
+          return "SCREEN-UUID"
+        end,
+      }
+    end,
+    watcher = {
+      new = function(fn)
+        return {
+          fn = fn,
+          start = function(s)
+            return s
+          end,
+        }
+      end,
+    },
+  },
+  timer = {
+    new = function(_, fn)
+      return {
+        fn = fn,
+        start = function(s)
+          return s
+        end,
+      }
+    end,
+  },
+  task = {
+    new = function(_, cb)
+      return {
+        start = function(s)
+          cb(0, stdout, "")
+          return s
+        end,
+        isRunning = function()
+          return false
+        end,
+      }
+    end,
+  },
+}
+
+-- ---------------------------------------------------------------------------
+-- Harness
+-- ---------------------------------------------------------------------------
+local function load_with(out)
+  stdout = out
+  reset()
+  rawset(canvas, "_f", nil)
+  -- Cleared per load the way init.lua clears them on every hs.reload().
+  _G.__hsReserved = {}
+  _G.__hsHyperExtras = {}
+
+  -- Mirrors init.lua's usableFrame closely enough to check the contract the
+  -- panel depends on: that a right-edge claim narrows the usable area, and that
+  -- reclaim is handed the frame as it was BEFORE the claim changed.
+  _G.__hsUsableFrame = function()
+    local f = { x = SCREEN.x, y = SCREEN.y, w = SCREEN.w, h = SCREEN.h }
+    for _, r in pairs(_G.__hsReserved) do
+      if r.screen == "SCREEN-UUID" and r.edge == "right" then
+        f.w = f.w - r.size
+      end
+    end
+    return f
+  end
+  _G.__hsReclaim = function(_, oldFrame)
+    reclaims[#reclaims + 1] = oldFrame
+  end
+
+  dofile(PANEL)
+end
+
+-- Hyper+P, reached the way the eventtap reaches it.
+local function pressToggle()
+  reset()
+  _G.__hsHyperExtras[35]()
+end
+
+local function claim()
+  return _G.__hsReserved.todoistPanel
+end
+
+-- Re-fires the already-loaded instance, the way the refresh timer does. This is
+-- the only way to reach the transitions (list emptying, list coming back),
+-- which a fresh dofile can never show.
+local function tick(out)
+  stdout = out
+  reset()
+  _G.__todoistPanelRetain.timer.fn()
+end
+
+local function text()
+  local s = ""
+  for _, c in ipairs(captured) do
+    s = s .. c.s
+  end
+  return s
+end
+
+local function lastFrame()
+  return calls.frames[#calls.frames]
+end
+
+-- The count out of the header line, rather than the whole string: these checks
+-- are about the NUMBER, and pinning the surrounding text made every cosmetic
+-- change to the header look like a counting bug.
+local function headerCount()
+  return tonumber(captured[1].s:match("(%d+)"))
+end
+
+local function rowsOf(n, state)
+  local t = {}
+  for i = 1, n do
+    t[i] = (state or "normal") .. "\ttask " .. i
+  end
+  return table.concat(t, "\n")
+end
+
+-- Drives the SCREEN rather than overriding maxTasks. The installed file carries
+-- a nix-generated `_G.__todoistPanelCfg` prelude that reassigns maxTasks on
+-- every load, so a test that set it would pass locally against the bare source
+-- and prove nothing about the file actually shipped.
+local function withScreen(h, fn)
+  local saved = SCREEN
+  SCREEN = { x = 0, y = 25, w = 1440, h = h }
+  local okRun, err = pcall(fn)
+  SCREEN = saved
+  if not okRun then
+    error(err, 0)
+  end
+end
+
+-- Read back the config the panel actually loaded, so this file keeps passing
+-- when the nix options change rather than pinning yesterday's numbers.
+load_with(rowsOf(1))
+local cfg = _G.__todoistPanelCfg or {}
+local WIDTH = cfg.width or 300
+local MAX = cfg.maxTasks or 12
+
+-- The panel is full-height now, so its frame says nothing about how many rows
+-- it drew. Everything below counts STYLED RUNS instead: one for the header,
+-- then one per row (plus the "+N more" line when it overflows). That is the
+-- thing actually worth asserting, and it does not move when padding does.
+local function drawnRows()
+  return #captured - 1
+end
+
+local function rowText(i)
+  return captured[i + 1].s
+end
+
+-- ---------------------------------------------------------------------------
+-- Checks
+-- ---------------------------------------------------------------------------
+local ok = 0
+local function check(name, fn)
+  -- Per-check, because hs.settings is persistent by design: a check that
+  -- collapses the panel would otherwise leave every later check running against
+  -- a collapsed one, which passes vacuously instead of failing.
+  SETTINGS = {}
+  fn()
+  ok = ok + 1
+  print(string.format("ok %d - %s", ok, name))
+end
+
+check("docks flush to the right edge, below the menu bar", function()
+  load_with(rowsOf(7))
+  local f = lastFrame()
+  assert(calls.show == 1, "panel should be shown")
+  assert(f.x == SCREEN.x + SCREEN.w - WIDTH, "x should be right-docked, got " .. f.x)
+  assert(f.y == SCREEN.y, "y should clear the menu bar, got " .. f.y)
+  assert(f.w == WIDTH, "width should match config, got " .. f.w)
+  assert(f.h == SCREEN.h, "panel should span the full usable height, got " .. f.h)
+  assert(drawnRows() == 7, "should draw 7 rows, drew " .. drawnRows())
+end)
+
+check("header counts the rows on screen", function()
+  load_with(rowsOf(7))
+  assert(headerCount() == 7, "bad header: " .. tostring(captured[1].s))
+end)
+
+check("emptying the list keeps the pane and says so", function()
+  load_with(rowsOf(3))
+  tick("")
+  assert(calls.hide == 0, "an expanded pane must not vanish; the strip is still reserved")
+  assert(calls.show == 1, "it should redraw")
+  assert(headerCount() == 0, "header should read 0")
+  assert(text():find("nothing due", 1, true), "should say the list is clear")
+end)
+
+check("tasks coming back re-show it without a reload", function()
+  load_with(rowsOf(3))
+  tick("")
+  tick(rowsOf(2))
+  assert(calls.show == 1, "should be shown again")
+  assert(drawnRows() == 2, "should draw the 2 new rows, drew " .. drawnRows())
+end)
+
+check("cold start with nothing due still draws the pane", function()
+  load_with("")
+  assert(calls.show == 1, "the reserved strip must not be left empty")
+  assert(headerCount() == 0 and text():find("nothing due", 1, true), "should show the clear state")
+end)
+
+-- The header must count everything DUE, not everything DRAWN. A panel reading
+-- "TODAY · 13" beside a tmux widget reading 20 makes both numbers worthless,
+-- and undercounting the day is the specific way this surface would fail its job.
+check("header counts hidden rows too, so it matches the tmux widget", function()
+  withScreen(4000, function()
+    load_with(rowsOf(MAX + 8))
+    assert(
+      headerCount() == MAX + 8,
+      "header must show the true total, got " .. captured[1].s
+    )
+  end)
+end)
+
+check("overflow collapses into a +N more row", function()
+  load_with(rowsOf(MAX + 8))
+  local t = text()
+  assert(t:find("%+8 more"), "expected '+8 more', got:\n" .. t)
+  assert(t:find("task " .. MAX, 1, true), "row " .. MAX .. " should be present")
+  assert(not t:find("task " .. (MAX + 1), 1, true), "row " .. (MAX + 1) .. " should be capped out")
+  assert(drawnRows() == MAX + 1, "should draw maxTasks rows plus the +N line, drew " .. drawnRows())
+end)
+
+-- The regression these two exist for: at the default maxTasks the panel is far
+-- shorter than any normal screen, so a broken bound stays invisible until
+-- someone raises the option or docks to a small display.
+check("a screen too short for maxTasks rows still fits, and says so", function()
+  withScreen(200, function()
+    load_with(rowsOf(500))
+    local f = lastFrame()
+    assert(f.h == 200, "panel should still be exactly full height, got " .. f.h)
+    -- Stated as a comparison against the roomy case rather than against a row
+    -- height copied from the panel: if the budget ignored screen height, this
+    -- short pane would draw the same maxTasks rows as a 4000pt one and run them
+    -- straight off the bottom, where they cannot be read.
+    assert(
+      drawnRows() < MAX + 1,
+      "a 200pt pane drew " .. drawnRows() .. " rows, same as a tall one -- they overflow"
+    )
+    assert(text():find("%+%d+ more"), "rows dropped for space must still be counted")
+  end)
+end)
+
+check("a screen with room to spare is bounded by maxTasks", function()
+  withScreen(4000, function()
+    load_with(rowsOf(500))
+    assert(
+      drawnRows() == MAX + 1,
+      "should stop at maxTasks(" .. MAX .. ") + the +N row, drew " .. drawnRows()
+    )
+  end)
+end)
+
+-- Relationships, not thresholds: "red is redder than it is green" survives a
+-- palette tweak, where "red > 0.8" turns every theme change into a failure.
+local function isRed(c)
+  return c.red > c.green * 2 and c.red > c.blue * 2
+end
+local function isAmber(c)
+  return c.red > 0.5 and c.green > 0.4 and c.blue < 0.2
+end
+-- The panel draws on Flexoki paper, so body text has to be the dark end.
+local function readsOnPaper(c)
+  return (c.red + c.green + c.blue) / 3 < 0.4
+end
+
+check("state routes to a colour; overdue and urgent are red", function()
+  load_with("overdue\tslipped\nurgent\tp1\nmedium\tp2\nnormal\tplain\n")
+  local overdue, urgent, medium, normal = captured[2], captured[3], captured[4], captured[5]
+  assert(isRed(overdue.color), "overdue should be red")
+  assert(isRed(urgent.color), "urgent should be red")
+  assert(isAmber(medium.color), "medium should be amber")
+  assert(readsOnPaper(normal.color), "normal must be dark enough to read on the paper background")
+end)
+
+check("every row colour is legible on the panel background", function()
+  load_with("overdue\ta\nurgent\tb\nmedium\tc\nnormal\td\n")
+  for i = 2, 5 do
+    local c = captured[i].color
+    -- Flexoki paper is ~0.93 luminance; anything near it vanishes.
+    assert(
+      (c.red + c.green + c.blue) / 3 < 0.75,
+      "row " .. i .. " is too light to read on #F2F0E5"
+    )
+  end
+end)
+
+check("an unrecognised state falls back to the normal colour", function()
+  load_with("banana\tsomething\n")
+  assert(calls.show == 1, "should still render")
+  assert(captured[2].color ~= nil, "should not render colourless")
+end)
+
+check("task text containing spaces and non-ascii survives the split", function()
+  load_with("normal\tBuy tickets to São Paulo — Sept 7 to 19\n")
+  assert(text():find("São Paulo", 1, true), "text should round-trip intact")
+end)
+
+check("blank and malformed lines are skipped, not drawn", function()
+  load_with("normal\tgood\n\nnotabhere\n\nmedium\talso good\n")
+  assert(headerCount() == 2, "only well-formed rows count: " .. captured[1].s)
+end)
+
+check("long-lived objects are retained against GC", function()
+  load_with(rowsOf(1))
+  local r = _G.__todoistPanelRetain
+  assert(r and r.timer, "refresh timer must be retained or it silently stops")
+  assert(r.screens, "screen watcher must be retained or it silently stops")
+end)
+
+check("screen watcher repositions without recreating the canvas", function()
+  load_with(rowsOf(4))
+  local before = calls.show
+  SCREEN = { x = 0, y = 25, w = 3840, h = 2000 }
+  _G.__todoistPanelRetain.screens.fn()
+  assert(lastFrame().x == 3840 - WIDTH, "should re-dock to the new screen width")
+  assert(calls.show == before, "repositioning should not re-show/recreate")
+  SCREEN = { x = 0, y = 25, w = 1920, h = 1055 }
+end)
+
+-- ---------------------------------------------------------------------------
+-- Collapse / expand + the reserved edge
+-- ---------------------------------------------------------------------------
+
+check("claims a right-edge reservation on the panel's screen when shown", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  local c = claim()
+  assert(c, "should claim an edge")
+  assert(c.edge == "right" and c.size == WIDTH, "bad claim: " .. c.edge .. "/" .. c.size)
+  assert(c.screen == "SCREEN-UUID", "claim must be keyed by screen UUID, got " .. tostring(c.screen))
+end)
+
+check("Hyper+P collapses: panel hides and the edge is released", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  pressToggle()
+  assert(calls.hide == 1, "panel should hide")
+  assert(claim() == nil, "reservation must be released so windows reclaim the strip")
+end)
+
+check("Hyper+P again expands: panel returns and reclaims the edge", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  pressToggle()
+  pressToggle()
+  assert(calls.show == 1, "panel should come back")
+  assert(claim() ~= nil, "reservation must be reclaimed")
+end)
+
+-- The regression that makes "collapsible" real: init.lua runs a full
+-- hs.reload() on systemDidWake and screensDidUnlock, so a plain in-memory flag
+-- would put the panel back on screen every single time the lid opens.
+check("collapsed survives a reload (lid close / wake)", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  pressToggle()
+  load_with(rowsOf(3))
+  assert(calls.show == 0, "panel must stay collapsed across a reload")
+  assert(claim() == nil, "and must not silently re-claim the edge")
+end)
+
+check("expanded also survives a reload", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  pressToggle()
+  pressToggle()
+  load_with(rowsOf(3))
+  assert(calls.show == 1, "panel must come back expanded")
+  assert(claim() ~= nil, "and re-claim the edge")
+end)
+
+check("the claim holds at zero tasks, so windows do not resize all day", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  tick("")
+  assert(calls.hide == 0, "the pane stays up")
+  assert(claim() ~= nil, "but the strip stays reserved while toggled on")
+end)
+
+check("collapsed stays collapsed when new tasks arrive", function()
+  SETTINGS = {}
+  load_with(rowsOf(1))
+  pressToggle()
+  tick(rowsOf(9))
+  assert(calls.show == 0, "a new task must not pop the drawer back open")
+end)
+
+-- ---------------------------------------------------------------------------
+-- Looks like the terminal
+-- ---------------------------------------------------------------------------
+
+check("background is solid and square, not a translucent rounded widget", function()
+  load_with(rowsOf(2))
+  local bg = rawget(canvas, 1)
+  assert(bg and bg.type == "rectangle", "element 1 should be the background")
+  assert(
+    (bg.fillColor.alpha or 1) == 1,
+    "background must be opaque, got alpha " .. tostring(bg.fillColor.alpha)
+  )
+  assert(bg.roundedRectRadii == nil, "a terminal pane has square corners")
+end)
+
+check("every line uses the terminal's own monospace font", function()
+  load_with(rowsOf(2))
+  -- Header + 2 rows. Without this the loop below runs zero times and passes
+  -- while proving nothing, which is exactly how it first "passed".
+  assert(#captured == 3, "expected 3 styled runs, got " .. #captured)
+  for i = 1, #captured do
+    local f = captured[i].font
+    assert(f and f.name, "line " .. i .. " has no font set")
+    assert(
+      f.name:find("Caskaydia"),
+      "line " .. i .. " should use Ghostty's font, got " .. f.name
+    )
+  end
+end)
+
+check("header carries the same nerd-font glyph as the tmux widget", function()
+  load_with(rowsOf(2))
+  -- U+F0AE nf-fa-tasks, as UTF-8 bytes.
+  assert(captured[1].s:find("\239\130\174", 1, true), "header should print the tasks glyph")
+end)
+
+-- ---------------------------------------------------------------------------
+-- Windows follow the edge
+-- ---------------------------------------------------------------------------
+
+-- The ordering bug this pins: reclaim identifies windows to move by the frame
+-- they currently fill, so it must be handed the usable frame from BEFORE the
+-- claim changed. Read it after and every window fails to match, the reclaim
+-- silently moves nothing, and the panel just overlaps again.
+check("collapsing hands reclaim the NARROW frame, so windows grow into the strip", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  pressToggle()
+  assert(#reclaims == 1, "reclaim should run exactly once, ran " .. #reclaims)
+  assert(
+    reclaims[1].w == SCREEN.w - WIDTH,
+    "must pass the pre-collapse (narrow) frame, got w=" .. reclaims[1].w
+  )
+end)
+
+check("expanding hands reclaim the FULL frame, so windows shrink out of it", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  pressToggle()
+  pressToggle()
+  assert(#reclaims == 1, "reclaim should run once per toggle")
+  assert(
+    reclaims[1].w == SCREEN.w,
+    "must pass the pre-expand (full) frame, got w=" .. reclaims[1].w
+  )
+end)
+
+check("the claimed size matches what the panel actually draws", function()
+  SETTINGS = {}
+  load_with(rowsOf(3))
+  local drawn = lastFrame()
+  assert(
+    claim().size == drawn.w,
+    "a strip reserved wider or narrower than the panel leaves a gap: claim="
+      .. claim().size
+      .. " drawn="
+      .. drawn.w
+  )
+  assert(
+    drawn.x + drawn.w == SCREEN.x + SCREEN.w,
+    "the panel must sit flush against the screen edge it reserved"
+  )
+end)
+
+print(string.format("\nall %d checks passed", ok))

--- a/modules/cli/todoist-panel.lua
+++ b/modules/cli/todoist-panel.lua
@@ -1,0 +1,344 @@
+-- Todoist ambient panel — the list itself, on screen all day, beside the work.
+--
+-- The tmux widget shows a COUNT, and only while a terminal is visible. This is
+-- the other half: the actual rows, docked to one screen, above every window and
+-- on every Space, so remembering is not a thing that has to be done on purpose.
+--
+-- Read-only, deliberately. Triage is hyper+T — the same picker as `t` in a pane
+-- and prefix+t in tmux — and this surface is the reminder, not the tool. A panel
+-- you can click is a panel you fiddle with instead of working, and the whole
+-- point of an ambient surface is that it costs nothing to ignore.
+--
+-- Rows come from todoist-panel-data, which reads the SAME cache and the same
+-- today/sort/priority definitions as the tmux widget. One definition, two
+-- surfaces: a panel that disagreed with the count in the bar about what is due
+-- today would make both of them untrustworthy.
+--
+-- Loaded by init.lua's extras loader; see modules/cli/todoist.nix for the
+-- home-manager drop and the _G.__todoistPanelCfg prelude it prepends.
+
+-- ---------------------------------------------------------------------------
+-- ⚠️  RETENTION — see the GC warning at the top of init.lua ⚠️
+-- ---------------------------------------------------------------------------
+-- hs.timer / hs.screen.watcher userdata have __gc finalizers that STOP the
+-- underlying OS object. Nothing in Hammerspoon retains them for us, so a plain
+-- `local t = hs.timer.new(...)` goes out of scope when this chunk finishes and
+-- dies silently minutes later. Everything long-lived goes in this table.
+_G.__todoistPanelRetain = {}
+local retain = _G.__todoistPanelRetain
+
+local cfg = _G.__todoistPanelCfg or {}
+local WIDTH = cfg.width or 300
+local MAX = cfg.maxTasks or 12
+local SCREEN = cfg.screen
+local EVERY = cfg.refresh or 60
+
+-- Same reason init.lua spells out the path for tmux-todoist-pick: this file is
+-- installed with `source =`, so nix cannot interpolate a store path into it.
+local DATA = os.getenv("HOME") .. "/.nix-profile/bin/todoist-panel-data"
+
+-- Flexoki Light — the palette the tmux widgets already use, and the theme
+-- Ghostty is set to. The point is that this reads as one more pane of the
+-- terminal rather than a widget parked beside it.
+--
+-- Fully opaque, because it owns its strip now (see the reservation below).
+-- Translucency was for floating over windows; against a wallpaper it was most
+-- of why the thing looked pasted on.
+--
+-- Written as rgb floats rather than {hex=...} so nothing here depends on which
+-- colour-table spellings hs.drawing accepts. Hex kept alongside for grepping.
+local COLORS = {
+  bg = { red = 0.949, green = 0.941, blue = 0.898, alpha = 1.0 }, -- #F2F0E5 paper
+  border = { red = 0.855, green = 0.847, blue = 0.808 }, -- #DAD8CE ui-2
+  head = { red = 0.435, green = 0.431, blue = 0.412 }, -- #6F6E69 tx-2
+  overdue = { red = 0.820, green = 0.302, blue = 0.255 }, -- #D14D41
+  urgent = { red = 0.820, green = 0.302, blue = 0.255 }, -- #D14D41
+  medium = { red = 0.816, green = 0.635, blue = 0.082 }, -- #D0A215
+  normal = { red = 0.063, green = 0.059, blue = 0.059 }, -- #100F0F tx
+}
+
+-- Ghostty's exact font and size. The proportional font was the other half of
+-- why this did not read as a terminal — nothing lined up down the left edge.
+local FONT = { name = "CaskaydiaCove Nerd Font", size = 12 }
+
+-- nf-fa-tasks, the same glyph the tmux widget prints, written as bytes rather
+-- than pasted in: a bare U+F0AE is invisible in every diff and survives only
+-- until some tool in the chain normalises it away. UTF-8 is EF 82 AE.
+local ICON = "\239\130\174"
+
+-- Tuned to the 12pt monospace above, so rows sit at terminal line spacing
+-- rather than UI-list spacing.
+local ROW_H = 17
+local HEAD_H = 20
+local PAD = 12
+
+local panel = nil
+-- The rows actually drawn, capped by rowBudget, plus the "+N more" line.
+local rows = {}
+-- Everything due, including what did not fit. The header counts THIS: a panel
+-- reading 13 while the tmux widget reads 20 makes both numbers worthless, and
+-- an ADHD-facing count that understates the day is the one failure that matters.
+local total = 0
+
+-- Both tables belong to init.lua, which resets them on every load; the fallback
+-- is so this file still loads standalone (its own test does exactly that).
+_G.__hsReserved = _G.__hsReserved or {}
+_G.__hsHyperExtras = _G.__hsHyperExtras or {}
+
+-- Persisted, not a plain local: init.lua does a full hs.reload() on every wake
+-- and screen unlock, so an in-memory flag would put the panel back on screen
+-- every time the lid opens — the one behaviour "collapsible" has to rule out.
+local SETTING = "todoistPanelVisible"
+local visible = hs.settings.get(SETTING)
+if visible == nil then
+  visible = true
+end
+
+-- ---------------------------------------------------------------------------
+-- Placement
+-- ---------------------------------------------------------------------------
+
+-- Falls back to primary whenever the configured screen is not attached, so
+-- unplugging the external monitor moves the panel instead of losing it.
+local function targetScreen()
+  if SCREEN then
+    local found = hs.screen.find(SCREEN)
+    if found then
+      return found
+    end
+  end
+  return hs.screen.primaryScreen()
+end
+
+-- Claimed while the panel is toggled ON, regardless of how many rows are
+-- showing. Tying the claim to the row count instead would resize every window
+-- on the screen as tasks get completed through the day — a reserved edge is
+-- only worth having if it stays put, so an empty list keeps the space and just
+-- stops drawing in it.
+local function reserve()
+  local screen = visible and targetScreen() or nil
+  _G.__hsReserved.todoistPanel = screen
+      and { screen = screen:getUUID(), edge = "right", size = WIDTH }
+    or nil
+end
+
+-- How many rows fit on the target screen. maxTasks is the ceiling, but a short
+-- screen outranks it: a row drawn past the bottom edge is a row that is not
+-- there, and it has to be counted in "+N more" rather than silently lost.
+--
+-- One rule instead of two. Clamping the panel HEIGHT to the screen was the
+-- obvious alternative and is worse — it produces a box the right size with rows
+-- painted outside it, so the list looks complete while hiding exactly the
+-- overdue items the sort worked to float to the top.
+--
+-- The -1 reserves the "+N more" slot unconditionally. Reserving it only when
+-- there is overflow costs a branch to save one row on a screen tall enough for
+-- fifty, and this way the height is provably <= the screen by construction.
+local function rowBudget()
+  local screen = targetScreen()
+  if not screen then
+    return MAX
+  end
+  local fits = math.floor((screen:frame().h - (PAD * 2) - HEAD_H) / ROW_H) - 1
+  if fits < 1 then
+    fits = 1
+  end
+  if fits > MAX then
+    fits = MAX
+  end
+  return fits
+end
+
+-- :frame() rather than :fullFrame() — the usable area, so the panel starts
+-- below the menu bar and stops above the Dock instead of sliding under either.
+--
+-- Full height, not the height of the content. It occupies a reserved strip, and
+-- a strip that windows are kept out of has to look occupied for its whole
+-- length: a short box floating in a tall empty column reads as a bug, not as a
+-- short list. This also makes the height independent of the row count, so
+-- nothing on screen moves as tasks are completed through the day.
+local function place()
+  if not panel then
+    return
+  end
+  local screen = targetScreen()
+  if not screen then
+    return
+  end
+  local f = screen:frame()
+  panel:frame({
+    x = f.x + f.w - WIDTH,
+    y = f.y,
+    w = WIDTH,
+    h = f.h,
+  })
+end
+
+-- ---------------------------------------------------------------------------
+-- Rendering
+-- ---------------------------------------------------------------------------
+
+local function styled()
+  -- Icon then count, the same shape and the same glyph as the tmux status
+  -- widget, so the number you glance at is in the same language on both.
+  local out = hs.styledtext.new(
+    string.format("%s  %d today\n", ICON, total),
+    { font = FONT, color = COLORS.head }
+  )
+  -- The reward state still has to fill the pane. Silence was right when this
+  -- was a floating box that could just vanish; now that it holds a reserved
+  -- strip, drawing nothing would leave a tall empty column that looks broken.
+  if total == 0 then
+    return out .. hs.styledtext.new("nothing due", { font = FONT, color = COLORS.head })
+  end
+
+  for _, row in ipairs(rows) do
+    out = out
+      .. hs.styledtext.new(row.text .. "\n", {
+        font = FONT,
+        color = COLORS[row.state] or COLORS.normal,
+      })
+  end
+  return out
+end
+
+local function render()
+  -- Collapsed is the only thing that hides it now. An empty list keeps the pane
+  -- (see styled), because the strip stays reserved either way and an unoccupied
+  -- reserved strip is just a hole in the desktop.
+  if not visible then
+    if panel then
+      panel:hide()
+    end
+    return
+  end
+
+  if not panel then
+    panel = hs.canvas.new({ x = 0, y = 0, w = WIDTH, h = 100 })
+    -- floating = above ordinary windows, below system alerts.
+    panel:level(hs.canvas.windowLevels.floating)
+    -- canJoinAllSpaces so switching Spaces does not take the list away;
+    -- stationary so Mission Control leaves it where it is.
+    panel:behavior({ "canJoinAllSpaces", "stationary" })
+    -- No mouseCallback anywhere in this file, which is what keeps the canvas
+    -- click-through: hs.canvas sets ignoresMouseEvents until one is registered.
+    -- Square, not rounded. Rounded corners read as a floating widget; this is
+    -- a pane sitting in its own strip, and terminals do not have rounded panes.
+    panel[1] = {
+      type = "rectangle",
+      action = "fill",
+      frame = { x = "0%", y = "0%", w = "100%", h = "100%" },
+      fillColor = COLORS.bg,
+    }
+    -- The tmux pane divider, and the only thing separating the panel from
+    -- whatever window now ends exactly where it begins.
+    panel[2] = {
+      type = "rectangle",
+      action = "fill",
+      frame = { x = 0, y = 0, w = 1, h = "100%" },
+      fillColor = COLORS.border,
+    }
+    panel[3] = {
+      type = "text",
+      frame = { x = PAD, y = PAD, w = WIDTH - (PAD * 2), h = 100 },
+      text = "",
+    }
+  end
+
+  place()
+  local f = panel:frame()
+  panel[3].frame = { x = PAD, y = PAD, w = WIDTH - (PAD * 2), h = f.h - (PAD * 2) }
+  panel[3].text = styled()
+  panel:show()
+end
+
+-- ---------------------------------------------------------------------------
+-- Collapse / expand
+-- ---------------------------------------------------------------------------
+
+-- Hyper+P, claimed through init.lua's extras hook so this file never has to
+-- touch the eventtap. Hyper+T stays the triage popup; this is only the drawer.
+local function toggle()
+  local screen = targetScreen()
+  -- Captured BEFORE the claim changes, because reclaim identifies the windows
+  -- to move by the frame they currently fill. Read after, every window would
+  -- already fail to match and nothing would resize.
+  local before = screen and _G.__hsUsableFrame and _G.__hsUsableFrame(screen) or nil
+
+  visible = not visible
+  hs.settings.set(SETTING, visible)
+  reserve()
+  render()
+
+  -- Windows that were filling the old area follow the edge: collapsing gives
+  -- the strip back to them, expanding takes it. Guarded because this file also
+  -- loads without init.lua (its own test does exactly that).
+  if before and _G.__hsReclaim then
+    _G.__hsReclaim(screen, before)
+  end
+
+  hs.alert.show(visible and "tasks panel" or "tasks panel hidden", 0.7)
+end
+
+local pCode = hs.keycodes.map["p"]
+if pCode then
+  _G.__hsHyperExtras[pCode] = toggle
+end
+
+-- ---------------------------------------------------------------------------
+-- Data
+-- ---------------------------------------------------------------------------
+
+-- hs.task rather than hs.execute: this fires on a timer for as long as the
+-- machine is up, and blocking Hammerspoon's run loop on a subprocess is how the
+-- health checks in init.lua start missing their ticks.
+local function refresh()
+  if retain.job and retain.job:isRunning() then
+    return
+  end
+  retain.job = hs.task.new(DATA, function(_, stdout, _)
+    rows = {}
+    total = 0
+    local budget = rowBudget()
+    for line in (stdout or ""):gmatch("[^\n]+") do
+      local state, text = line:match("^([^\t]*)\t(.*)$")
+      if state then
+        total = total + 1
+        if #rows < budget then
+          rows[#rows + 1] = { state = state, text = text }
+        end
+      end
+    end
+    -- A count rather than the rows themselves. Computed before the row is
+    -- appended, because appending changes #rows.
+    local hidden = total - #rows
+    if hidden > 0 then
+      rows[#rows + 1] = { state = "head", text = string.format("+%d more", hidden) }
+    end
+    render()
+  end)
+  retain.job:start()
+end
+
+-- ---------------------------------------------------------------------------
+-- Lifecycle
+-- ---------------------------------------------------------------------------
+
+-- The cache is normally kept warm by the tmux widget's 5s tick; todoist-panel-data
+-- re-fetches it itself when it has gone stale, which is what makes this panel
+-- work on a machine with no terminal open.
+retain.timer = hs.timer.new(EVERY, refresh)
+retain.timer:start()
+
+-- Reposition on monitor attach/detach/rearrange rather than recreating: the
+-- canvas survives the change, only its frame is wrong. The claim is re-made
+-- too, because it is keyed by screen UUID and the panel may have just fallen
+-- back to the built-in display.
+retain.screens = hs.screen.watcher.new(function()
+  reserve()
+  place()
+end)
+retain.screens:start()
+
+reserve()
+refresh()

--- a/modules/cli/todoist.nix
+++ b/modules/cli/todoist.nix
@@ -31,19 +31,62 @@ mkUserModule {
     darwin.homebrew.brews = [ "todoist-cli" ];
   };
 
-  extraOptions.warnAt = lib.mkOption {
-    type = lib.types.int;
-    default = 15;
-    description = "Open-task count at which the tmux widget starts escalating.";
-  };
+  extraOptions = {
+    warnAt = lib.mkOption {
+      type = lib.types.int;
+      default = 15;
+      description = "Open-task count at which the tmux widget starts escalating.";
+    };
 
-  extraOptions.reviewAt = lib.mkOption {
-    type = lib.types.nullOr lib.types.str;
-    default = "06:00";
-    example = "07:30";
-    description = ''
-      Local time of day, "HH:MM", for the daily start review. null disables it.
-    '';
+    reviewAt = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = "06:00";
+      example = "07:30";
+      description = ''
+        Local time of day, "HH:MM", for the daily start review. null disables it.
+      '';
+    };
+
+    # The ambient half. The tmux widget puts a count where you already are; this
+    # puts the rows there, on a monitor, above everything, on every Space — the
+    # surface that needs neither a keypress nor a visible terminal to work.
+    #
+    # Needs hammerspoon: it is drawn by an hs.canvas dropped into the extras
+    # loader, and there is no second implementation for a machine without it.
+    panel = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Always-visible Todoist panel docked to a screen edge.";
+      };
+
+      width = lib.mkOption {
+        type = lib.types.int;
+        default = 300;
+        description = "Panel width in points.";
+      };
+
+      maxTasks = lib.mkOption {
+        type = lib.types.int;
+        default = 12;
+        description = ''
+          Rows to draw before collapsing the rest into a "+N more" line. The cap
+          is what keeps the list shorter than the screen — a panel that runs off
+          the bottom hides the overdue rows the sort worked to put at the top.
+        '';
+      };
+
+      screen = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "DELL U2720Q";
+        description = ''
+          Which monitor to dock to, as an hs.screen.find pattern (name, UUID, or
+          id). null uses the primary screen. An unattached screen falls back to
+          primary rather than taking the panel away.
+        '';
+      };
+    };
   };
 
   home =
@@ -1132,6 +1175,64 @@ mkUserModule {
 
       reviewEnabled = cfg.reviewAt != null;
 
+      # Both halves required: the panel IS an hs.canvas, so without hammerspoon
+      # there is nothing to draw it and the option would silently do nothing.
+      panelEnabled = cfg.panel.enable && userCfg.hammerspoon.enable;
+
+      # The rows behind the ambient panel. Reads the same cache as the widget
+      # and reuses the same today/sort definitions verbatim — a panel that
+      # disagreed with the count in the tmux bar about what is due today would
+      # make both of them untrustworthy.
+      todoist-panel-data = pkgs.writeShellApplication {
+        name = "todoist-panel-data";
+        bashOptions = [ ];
+        runtimeInputs = with pkgs; [
+          jq
+          findutils
+          gnugrep
+          coreutils
+        ];
+        text = ''
+          CACHE=${cache}
+
+          # The widget's 5s tick is what normally keeps this cache warm, and the
+          # whole point of the panel is working on a machine with no terminal
+          # open. Same 2-minute staleness rule as the widget, so the two
+          # surfaces cannot disagree about how old the list they draw is.
+          #
+          # Detached: the Hammerspoon side is on its own timer and re-reads
+          # shortly, so blocking on the round trip here would only delay the
+          # rows it already has.
+          if ! find "$CACHE" -mmin -2 2>/dev/null | grep -q .; then
+            ${tmux-todoist-refresh}/bin/tmux-todoist-refresh >/dev/null 2>&1 &
+          fi
+
+          [ -f "$CACHE" ] || exit 0
+
+          # state<TAB>text. The state NAMES a colour rather than carrying one,
+          # so every judgement about what is urgent stays here beside the sort
+          # that ordered it, and the Lua stays purely presentational.
+          #
+          # dueToday guarantees .due is non-null, so the overdue comparison
+          # cannot index a null. Same 10-char slice as everywhere else: due.date
+          # is a bare date for an all-day task and a full datetime for a timed
+          # one, and comparing those as strings is how a task due later today
+          # gets dropped.
+          jq -r --arg today "$(date +%F)" '
+            ${unwrap}
+            | ${dueToday}
+            | ${smartSort}
+            | .[]
+            | [ (if   ((.due.date | tostring)[0:10]) < $today then "overdue"
+                 elif (.priority // 1) == 4 then "urgent"
+                 elif (.priority // 1) == 3 then "medium"
+                 else "normal" end),
+                ((if (.priority // 1) >= 3 then "! " else "" end) + .content) ]
+            | @tsv
+          ' "$CACHE" 2>/dev/null
+        '';
+      };
+
       # "06:00" → { Hour = 6; Minute = 0; }. toIntBase10 rather than toInt:
       # toInt parses as JSON, where a leading zero is invalid, so "06" is an
       # eval error — which the default value would hit on every build.
@@ -1232,12 +1333,37 @@ mkUserModule {
       };
     in
     {
-      home.packages = lib.mkIf userCfg.tmux.enable [
-        tmux-todoist-refresh
-        tmux-todoist-widget
-        tmux-todoist-pick
-        tmux-todoist-review
-      ];
+      home.packages =
+        lib.optionals userCfg.tmux.enable [
+          tmux-todoist-refresh
+          tmux-todoist-widget
+          tmux-todoist-pick
+          tmux-todoist-review
+        ]
+        # On the profile rather than referenced by store path, because the Lua
+        # that calls it is installed with `source =` and cannot interpolate one
+        # — the same reason init.lua spells out ~/.nix-profile/bin for the
+        # popup.
+        ++ lib.optionals panelEnabled [ todoist-panel-data ];
+
+      # Outbound integration, per the repo rule: todoist is the module that
+      # knows what a task is, so it reaches into hammerspoon rather than the
+      # other way round. init.lua's extras loader picks the file up on its next
+      # reload, and hammerspoon stays unaware that todoist exists.
+      home.file.".hammerspoon/extras/todoist-panel.lua" = lib.mkIf panelEnabled {
+        # Prepended rather than templated through the body: the .lua stays valid
+        # on its own — it falls back to these same defaults when the prelude is
+        # absent — so nvim, luac and a bare `hs.dofile` can all still read the
+        # file in place.
+        text = ''
+          _G.__todoistPanelCfg = {
+            width = ${toString cfg.panel.width},
+            maxTasks = ${toString cfg.panel.maxTasks},
+            screen = ${if cfg.panel.screen == null then "nil" else ''"${cfg.panel.screen}"''},
+          }
+        ''
+        + builtins.readFile ./todoist-panel.lua;
+      };
 
       programs.tmux.extraConfig = lib.mkIf userCfg.tmux.enable ''
         # Todoist triage popup. This deliberately overrides tmux's default

--- a/modules/darwin/hammerspoon/init.lua
+++ b/modules/darwin/hammerspoon/init.lua
@@ -322,17 +322,133 @@ end
 -- Instant window ops — no slide animation.
 hs.window.animationDuration = 0
 
--- Hyper + F → Maximize the focused window on its current screen.
+-- Screen-edge reservations, claimed by extras (see the extras loader at the
+-- bottom). Each entry is { screen = <uuid>, edge = "left"|"right", size = <pt> },
+-- and the window ops below subtract them, so an extra that parks a panel on an
+-- edge does not get maximized over.
+--
+-- This is as far as reservation can go on macOS. There is NO public API for a
+-- third-party app to shrink everyone's usable area the way the Dock does —
+-- NSScreen.visibleFrame is read-only and Dock-private. The honest alternatives
+-- are a tiling WM that owns layout (yabai's external_bar), or an hs.window.filter
+-- that shoves intruding windows back out. The latter was measured and rejected:
+-- windowMoved is internally debounced by 0.5s, so windows visibly jump half a
+-- second after you drop them, and the filter has a long tail of beachball
+-- reports. Honouring the reservation in OUR OWN ops is instant and cannot fight
+-- the user — the cost is that a window dragged there by hand stays there.
+_G.__hsReserved = {}
+
+-- Extras can claim a Hyper key by keyCode here. Checked AFTER the built-in
+-- actions, so init.lua's own bindings always win and an extra cannot silently
+-- steal one.
+_G.__hsHyperExtras = {}
+
+-- The frame a window may actually occupy: the usable area (already excluding
+-- menu bar and Dock) minus every edge an extra has claimed on this screen.
+-- Copied into a plain table rather than mutated in place: screen:frame() hands
+-- back an hs.geometry object, and this code has no business depending on
+-- whether assigning to its .w is supported. setFrame takes a plain rect.
+local function usableFrame(screen)
+  local g = screen:frame()
+  local f = { x = g.x, y = g.y, w = g.w, h = g.h }
+  local uuid = screen:getUUID()
+  for _, r in pairs(_G.__hsReserved) do
+    if r.screen == uuid and r.size > 0 then
+      if r.edge == "right" then
+        f.w = f.w - r.size
+      elseif r.edge == "left" then
+        f.x = f.x + r.size
+        f.w = f.w - r.size
+      end
+    end
+  end
+  return f
+end
+
+-- Shrink-then-shift, so a window bigger than the bounds ends up inside them
+-- rather than merely nudged. Used when a window lands on a screen whose usable
+-- area is smaller than the one it came from.
+local function clampTo(g, b)
+  local f = { x = g.x, y = g.y, w = g.w, h = g.h }
+  if f.w > b.w then
+    f.w = b.w
+  end
+  if f.h > b.h then
+    f.h = b.h
+  end
+  if f.x < b.x then
+    f.x = b.x
+  end
+  if f.y < b.y then
+    f.y = b.y
+  end
+  if f.x + f.w > b.x + b.w then
+    f.x = b.x + b.w - f.w
+  end
+  if f.y + f.h > b.y + b.h then
+    f.y = b.y + b.h - f.h
+  end
+  return f
+end
+
+-- Tolerance rather than equality: apps round their frames, and a few refuse the
+-- exact size they were given, so a maximized window is rarely pixel-identical to
+-- the frame it was maximized to.
+local RECLAIM_TOLERANCE = 8
+
+local function nearlyEquals(a, b)
+  return math.abs(a.x - b.x) <= RECLAIM_TOLERANCE
+    and math.abs(a.y - b.y) <= RECLAIM_TOLERANCE
+    and math.abs(a.w - b.w) <= RECLAIM_TOLERANCE
+    and math.abs(a.h - b.h) <= RECLAIM_TOLERANCE
+end
+
+-- Published for extras that need to size themselves against a claimed edge.
+_G.__hsUsableFrame = usableFrame
+
+-- Called by an extra straight after it adds or drops a claim, with the usable
+-- frame as it was BEFORE the change. Windows that were filling the old area are
+-- grown or shrunk into the new one; anything the user deliberately sized is
+-- left exactly where it is, which is why this matches on the old frame instead
+-- of just re-maximizing everything.
+--
+-- macOS-native fullscreen windows are skipped: they live in their own Space and
+-- reframing one means yanking it out of that Space, which is not what toggling
+-- a side panel should do.
+_G.__hsReclaim = function(screen, oldFrame)
+  local target = usableFrame(screen)
+  for _, w in ipairs(hs.window.visibleWindows()) do
+    local okWin, err = pcall(function()
+      if
+        w:screen() == screen
+        and w:isStandard()
+        and not w:isFullScreen()
+        and nearlyEquals(w:frame(), oldFrame)
+      then
+        w:setFrame(target, 0)
+      end
+    end)
+    if not okWin then
+      log("ERROR", "reclaim: " .. tostring(err))
+    end
+  end
+end
+
+-- Hyper + F → Maximize the focused window on its current screen, up to any
+-- edge an extra has reserved. setFrame rather than :maximize(), which always
+-- takes the whole frame and would paint over a claimed strip.
 local fCode = hs.keycodes.map["f"]
 if fCode then
   keyCodeNames[fCode] = "f"
   hyperActionsByKeyCode[fCode] = function()
     local win = hs.window.focusedWindow()
-    if win then win:maximize() end
+    if win then win:setFrame(usableFrame(win:screen()), 0) end
   end
 end
 
--- Hyper + \ → Throw the focused window to the next screen (keeps its size).
+-- Hyper + \ → Throw the focused window to the next screen (keeps its size,
+-- clamped into that screen's usable area — the destination may be smaller, or
+-- may be the one carrying a reserved edge).
 local backslashCode = hs.keycodes.map["\\"]
 if backslashCode then
   keyCodeNames[backslashCode] = "\\"
@@ -340,6 +456,7 @@ if backslashCode then
     local win = hs.window.focusedWindow()
     if win then
       win:moveToScreen(win:screen():next())
+      win:setFrame(clampTo(win:frame(), usableFrame(win:screen())), 0)
       warpTo(win:screen(), hs.geometry.rectMidPoint(win:frame()))
     end
   end
@@ -443,7 +560,10 @@ local function f18Callback(event)
   -- Actions are deferred to the next run-loop iteration so the eventtap
   -- callback returns immediately. macOS silently disables CGEventTaps
   -- whose callbacks exceed ~300ms; hs.execute() can easily hit that.
-  local action = hyperActionsByKeyCode[keyCode]
+  -- Built-ins first, then anything an extra claimed. Merged into one local so
+  -- the deferral, autorepeat guard and pcall below cover both identically —
+  -- a broken extra must not be able to wedge the eventtap.
+  local action = hyperActionsByKeyCode[keyCode] or _G.__hsHyperExtras[keyCode]
   if action then
     hyperUsedAsModifier = true
     if event:getProperty(hs.eventtap.event.properties.keyboardEventAutorepeat) ~= 0 then

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -19,7 +19,10 @@ mkUser {
   ripgrep.enable = true;
   chrome-cli.enable = true;
   readwise.enable = true;
-  todoist.enable = true;
+  todoist = {
+    enable = true;
+    panel.enable = true;
+  };
 
   # Dev tools
   git.enable = true;


### PR DESCRIPTION
The tmux widget shows a count, and only while a terminal is visible. This is
the other half: the rows themselves, in a full-height pane docked to a screen
edge and present on every Space, so remembering is not something you have to
do on purpose.

The rows come from the same cache and the same today/sort/priority definitions
the widget uses, so the two surfaces cannot disagree about what is due — the
header counts everything due rather than everything drawn, for the same
reason. It renders through Hammerspoon's existing extras loader as an
hs.canvas, so there is no new cask, no new permission and no window-mirroring
hack; `td` was already installed and the cache was already being kept warm.

Hyper+P collapses it. That state goes through hs.settings rather than a local,
because init.lua reloads on every wake and screen unlock, and an in-memory
flag would reopen the drawer every time the lid opens.

macOS has no public way to reserve screen space — visibleFrame is read-only
and Dock-private — so the reservation is enforced in our own window ops
instead: hyper+F and hyper+\ stop at the claimed edge, and toggling the panel
takes the windows that were filling the old area with it. A window dragged
under the panel by hand still goes under it. The alternative was an
hs.window.filter that shoves intruders back out, and it was rejected on
measurement: windowMoved is internally debounced by half a second, so windows
visibly jump well after being dropped, and the filter has a long tail of
beachball reports behind it.

init.lua gains two generic hooks to make that possible — `_G.__hsReserved` for
edge claims and `_G.__hsHyperExtras` for keys — so hammerspoon still knows
nothing about todoist, and the panel reaches into it rather than the reverse.

The pane keeps its strip when the list is empty instead of vanishing the way
the widget does. Silence was right for a floating box that could disappear
without leaving a mark; a reserved strip with nothing drawn in it is just a
hole in the desktop.

Both Lua files are now covered by `nix flake check`: the panel through its own
assertions, and hammerspoon's init.lua by byte-compiling it. That one had no
syntax check at all, and a typo there takes the Caps Lock to Hyper eventtap
with it — leaving the fix to be typed on a keyboard whose Caps Lock no longer
works.

## Verification

- `nix flake check` — 3 checks pass (nvim init, hammerspoon init, todoist panel)
- `statix check .` clean, `nixfmt` applied
- 29 panel assertions pass, run against the *installed* file (nix prelude included)
- Mutation-tested: 23 deliberate bugs injected across the suite, 23 caught
- `todoist-panel-data` verified against the live cache
