### PR TITLE
feat(tmux): run agent sessions in POSIX sh instead of fish

### DIFF
--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -224,9 +224,11 @@ mkUserModule {
 
         Create your own windows, panes, and sessions freely — dev servers, log
         tails, anything long-running or interactive that would block your shell.
-        Name every session `agents/<name>`, always detached:
-        `tmux new-session -d -s agents/<name>` (you are already inside tmux, so
-        an attached `new-session` errors).
+        Name every session `agents/<name>`, always detached, running POSIX sh:
+        `tmux new-session -d -s agents/<name> '/bin/sh -l'` (you are already
+        inside tmux, so an attached `new-session` errors). Windows you add to
+        an `agents/*` session get sh too, so everything you run in one is
+        POSIX, never fish.
 
         Sessions named `agents/*` are yours: use and kill them freely, including
         leftovers from earlier runs. Every other session is mine — never kill,
@@ -255,6 +257,17 @@ mkUserModule {
           # for fast popup/run-shell jobs — see the shell option above). Pane
           # creation is rare, so the extra sh -c wrapper is irrelevant.
           set -g default-command "${pkgs.fish}/bin/fish -l"
+
+          # ...except agent sessions, which get POSIX sh: agents write
+          # bash-flavoured commands, and their send-keys lines would otherwise
+          # pile up in the fish history I share across every pane. Login sh
+          # (-l) because the tmux server's PATH is only tmux + /usr/bin —
+          # /etc/profile is what pulls the nix profile in. The hook fires after
+          # the session's first pane already started, so the AGENTS.md snippet
+          # above spells the command out for that one; every later window in
+          # the session picks it up from here. Index 10 because the
+          # session-picker part owns session-created[20].
+          set-hook -g 'session-created[10]' 'if -F "#{m:agents/*,#{session_name}}" "set default-command \"/bin/sh -l\""'
 
           set -g renumber-windows on
 


### PR DESCRIPTION
Agent tmux sessions inherit the global `default-command` (`fish -l`), so
agents land in a fish pane. They write bash-flavoured commands, hit fish
syntax errors, and retry — and every `send-keys` line they run piles up in
the fish history shared across all my panes.

A `session-created` hook sets `default-command` to `/bin/sh -l` for sessions
matching `agents/*`. Every window opened in such a session is sh from then
on. My own sessions are untouched and still get fish.

Login sh (`-l`) is required: the tmux server inherits a PATH of roughly
`tmux + /usr/bin` from launchd, and `/etc/profile` is what pulls the nix
profile in. Verified in an agent pane that `git rg fd jq gh nix` all resolve.

The hook fires after the new session's first pane has already spawned, so the
AGENTS.md snippet now spells the command out for that one pane; later windows
pick it up from the session option.

Hook index 10 — the session-picker part owns `session-created[20]`.

## Verified

- `agents/*` new window → sh, normal session new window → fish
- current session `default-command` unchanged
- `nixfmt` + `statix` clean