### PR TITLE
feat(linear): show active issues in the ambient panel

### DIFF
--- a/modules/cli/todoist-panel-test.lua
+++ b/modules/cli/todoist-panel-test.lua
@@ -216,13 +216,6 @@ local function lastFrame()
   return calls.frames[#calls.frames]
 end
 
--- The count out of the header line, rather than the whole string: these checks
--- are about the NUMBER, and pinning the surrounding text made every cosmetic
--- change to the header look like a counting bug.
-local function headerCount()
-  return tonumber(captured[1].s:match("(%d+)"))
-end
-
 local function rowsOf(n, state)
   local t = {}
   for i = 1, n do
@@ -253,15 +246,16 @@ local WIDTH = cfg.width or 300
 local MAX = cfg.maxTasks or 12
 
 -- The panel is full-height now, so its frame says nothing about how many rows
--- it drew. Everything below counts STYLED RUNS instead: one for the header,
--- then one per row (plus the "+N more" line when it overflows). That is the
--- thing actually worth asserting, and it does not move when padding does.
+-- it drew. Everything below counts STYLED RUNS instead: one per row it was
+-- handed, head rows included, plus the "+N more" line when it overflows. That
+-- is the thing actually worth asserting, and it does not move when padding
+-- does.
 local function drawnRows()
-  return #captured - 1
+  return #captured
 end
 
 local function rowText(i)
-  return captured[i + 1].s
+  return captured[i].s
 end
 
 -- ---------------------------------------------------------------------------
@@ -289,9 +283,19 @@ check("docks flush to the right edge, below the menu bar", function()
   assert(drawnRows() == 7, "should draw 7 rows, drew " .. drawnRows())
 end)
 
-check("header counts the rows on screen", function()
-  load_with(rowsOf(7))
-  assert(headerCount() == 7, "bad header: " .. tostring(captured[1].s))
+-- The count moved into the producers, because each one owns the definition its
+-- number is of: todoist-panel-data reads the same cache and the same today/sort
+-- rules as the tmux widget, so the two cannot disagree. A total summed here
+-- would have started counting linear issues as things "due today" the moment a
+-- second producer appeared. What this file still has to guarantee is that the
+-- panel passes head rows through untouched instead of recomputing them.
+check("producer head rows are drawn verbatim, not recomputed", function()
+  load_with("head\t\239\130\174  20 today\nnormal\ttask 1\n")
+  assert(rowText(1):find("20 today", 1, true), "head row should survive intact: " .. rowText(1))
+  -- U+F0AE nf-fa-tasks, as UTF-8 bytes: the glyph the tmux widget prints, and
+  -- the reason head rows must reach the canvas byte-for-byte.
+  assert(rowText(1):find("\239\130\174", 1, true), "the tasks glyph should survive the parse")
+  assert(drawnRows() == 2, "head row plus its task, drew " .. drawnRows())
 end)
 
 check("emptying the list keeps the pane and says so", function()
@@ -299,7 +303,6 @@ check("emptying the list keeps the pane and says so", function()
   tick("")
   assert(calls.hide == 0, "an expanded pane must not vanish; the strip is still reserved")
   assert(calls.show == 1, "it should redraw")
-  assert(headerCount() == 0, "header should read 0")
   assert(text():find("nothing due", 1, true), "should say the list is clear")
 end)
 
@@ -311,22 +314,34 @@ check("tasks coming back re-show it without a reload", function()
   assert(drawnRows() == 2, "should draw the 2 new rows, drew " .. drawnRows())
 end)
 
-check("cold start with nothing due still draws the pane", function()
+-- Reached only when NO producer said anything at all: every producer prints its
+-- own head row unconditionally, so this is the failed-fetch / nothing-installed
+-- case, and the reserved strip still must not be left looking broken.
+check("cold start with no producer output still draws the pane", function()
   load_with("")
   assert(calls.show == 1, "the reserved strip must not be left empty")
-  assert(headerCount() == 0 and text():find("nothing due", 1, true), "should show the clear state")
+  assert(text():find("nothing due", 1, true), "should show the clear state")
 end)
 
--- The header must count everything DUE, not everything DRAWN. A panel reading
--- "TODAY · 13" beside a tmux widget reading 20 makes both numbers worthless,
--- and undercounting the day is the specific way this surface would fail its job.
-check("header counts hidden rows too, so it matches the tmux widget", function()
+-- One pane, one row budget, however many producers. The failure this rules out
+-- is each section getting its own cap and the total running off the bottom of
+-- the screen, where the rows cannot be read and are not counted either.
+check("two producers share one pane, one budget and one +N more", function()
   withScreen(4000, function()
-    load_with(rowsOf(MAX + 8))
-    assert(
-      headerCount() == MAX + 8,
-      "header must show the true total, got " .. captured[1].s
+    load_with(
+      "head\tlinear  2 active\nnormal\tENG-1  a\nnormal\tENG-2  b\n"
+        .. "head\t\239\130\174  20 today\n"
+        .. rowsOf(MAX)
     )
+    local t = text()
+    assert(t:find("linear  2 active", 1, true), "the linear section should be drawn")
+    assert(t:find("20 today", 1, true), "the todoist section should be drawn")
+    assert(drawnRows() == MAX + 1, "budget is shared across sections, drew " .. drawnRows())
+    assert(t:find("%+5 more"), "overflow across both sections must be counted, got:\n" .. t)
+    -- The separator itself: a blank line, costing a budget slot like any row,
+    -- between the last linear row and the second section's head.
+    assert(rowText(4) == "\n", "row 4 should be the blank separator, got " .. rowText(4))
+    assert(rowText(5):find("20 today", 1, true), "row 5 should be the todoist head, got " .. rowText(5))
   end)
 end)
 
@@ -384,7 +399,7 @@ end
 
 check("state routes to a colour; overdue and urgent are red", function()
   load_with("overdue\tslipped\nurgent\tp1\nmedium\tp2\nnormal\tplain\n")
-  local overdue, urgent, medium, normal = captured[2], captured[3], captured[4], captured[5]
+  local overdue, urgent, medium, normal = captured[1], captured[2], captured[3], captured[4]
   assert(isRed(overdue.color), "overdue should be red")
   assert(isRed(urgent.color), "urgent should be red")
   assert(isAmber(medium.color), "medium should be amber")
@@ -393,7 +408,7 @@ end)
 
 check("every row colour is legible on the panel background", function()
   load_with("overdue\ta\nurgent\tb\nmedium\tc\nnormal\td\n")
-  for i = 2, 5 do
+  for i = 1, 4 do
     local c = captured[i].color
     -- Flexoki paper is ~0.93 luminance; anything near it vanishes.
     assert(
@@ -406,7 +421,7 @@ end)
 check("an unrecognised state falls back to the normal colour", function()
   load_with("banana\tsomething\n")
   assert(calls.show == 1, "should still render")
-  assert(captured[2].color ~= nil, "should not render colourless")
+  assert(captured[1].color ~= nil, "should not render colourless")
 end)
 
 check("task text containing spaces and non-ascii survives the split", function()
@@ -416,7 +431,8 @@ end)
 
 check("blank and malformed lines are skipped, not drawn", function()
   load_with("normal\tgood\n\nnotabhere\n\nmedium\talso good\n")
-  assert(headerCount() == 2, "only well-formed rows count: " .. captured[1].s)
+  assert(drawnRows() == 2, "only well-formed rows should be drawn, drew " .. drawnRows())
+  assert(not text():find("notabhere", 1, true), "a line with no tab is not a row")
 end)
 
 check("long-lived objects are retained against GC", function()
@@ -521,9 +537,9 @@ end)
 
 check("every line uses the terminal's own monospace font", function()
   load_with(rowsOf(2))
-  -- Header + 2 rows. Without this the loop below runs zero times and passes
-  -- while proving nothing, which is exactly how it first "passed".
-  assert(#captured == 3, "expected 3 styled runs, got " .. #captured)
+  -- Without this the loop below runs zero times and passes while proving
+  -- nothing, which is exactly how it first "passed".
+  assert(#captured == 2, "expected 2 styled runs, got " .. #captured)
   for i = 1, #captured do
     local f = captured[i].font
     assert(f and f.name, "line " .. i .. " has no font set")
@@ -532,12 +548,6 @@ check("every line uses the terminal's own monospace font", function()
       "line " .. i .. " should use Ghostty's font, got " .. f.name
     )
   end
-end)
-
-check("header carries the same nerd-font glyph as the tmux widget", function()
-  load_with(rowsOf(2))
-  -- U+F0AE nf-fa-tasks, as UTF-8 bytes.
-  assert(captured[1].s:find("\239\130\174", 1, true), "header should print the tasks glyph")
 end)
 
 -- ---------------------------------------------------------------------------

--- a/modules/cli/todoist-panel.lua
+++ b/modules/cli/todoist-panel.lua
@@ -9,10 +9,20 @@
 -- you can click is a panel you fiddle with instead of working, and the whole
 -- point of an ambient surface is that it costs nothing to ignore.
 --
--- Rows come from todoist-panel-data, which reads the SAME cache and the same
--- today/sort/priority definitions as the tmux widget. One definition, two
+-- Rows come from every *-panel-data on the profile, concatenated. That glob is
+-- the whole plugin protocol: a module with something worth seeing all day
+-- installs an executable with that suffix and prints state<TAB>text. Todoist
+-- ships todoist-panel-data, linear ships linear-panel-data, and neither has to
+-- know the other exists — except that todoist is not a guest here. This file
+-- IS its panel, so its section always leads; everything else follows behind
+-- it, separated by a blank line per section.
+--
+-- Each producer prints its OWN header as a head row, because each one owns the
+-- definition its count is of — todoist-panel-data reads the SAME cache and the
+-- same today/sort/priority definitions as the tmux widget. One definition, two
 -- surfaces: a panel that disagreed with the count in the bar about what is due
--- today would make both of them untrustworthy.
+-- today would make both of them untrustworthy, and a single total summed here
+-- would start doing exactly that the moment a second producer appeared.
 --
 -- Loaded by init.lua's extras loader; see modules/cli/todoist.nix for the
 -- home-manager drop and the _G.__todoistPanelCfg prelude it prepends.
@@ -35,7 +45,28 @@ local EVERY = cfg.refresh or 60
 
 -- Same reason init.lua spells out the path for tmux-todoist-pick: this file is
 -- installed with `source =`, so nix cannot interpolate a store path into it.
-local DATA = os.getenv("HOME") .. "/.nix-profile/bin/todoist-panel-data"
+--
+-- /bin/sh because the glob IS the extension point for GUESTS: any other module
+-- with something worth seeing all day drops its own *-panel-data on the
+-- profile and shows up here without this file ever learning its name. Todoist
+-- itself is not a guest — it owns this panel (installed by modules/cli/
+-- todoist.nix) — so it runs first, named directly, and everyone else follows
+-- in glob order.
+--
+-- The expansion lives inside the -c script rather than in this table because
+-- hs.task hands arguments to the executable verbatim, never through a shell.
+local DATA = "/bin/sh"
+local DATA_ARGS = {
+  "-c",
+  [[
+b="$HOME/.nix-profile/bin"
+[ -x "$b/todoist-panel-data" ] && "$b/todoist-panel-data"
+for f in "$b"/*-panel-data; do
+  [ "$f" = "$b/todoist-panel-data" ] && continue
+  [ -x "$f" ] && "$f"
+done
+]],
+}
 
 -- Flexoki Light — the palette the tmux widgets already use, and the theme
 -- Ghostty is set to. The point is that this reads as one more pane of the
@@ -61,11 +92,6 @@ local COLORS = {
 -- why this did not read as a terminal — nothing lined up down the left edge.
 local FONT = { name = "CaskaydiaCove Nerd Font", size = 12 }
 
--- nf-fa-tasks, the same glyph the tmux widget prints, written as bytes rather
--- than pasted in: a bare U+F0AE is invisible in every diff and survives only
--- until some tool in the chain normalises it away. UTF-8 is EF 82 AE.
-local ICON = "\239\130\174"
-
 -- Tuned to the 12pt monospace above, so rows sit at terminal line spacing
 -- rather than UI-list spacing.
 local ROW_H = 17
@@ -73,12 +99,10 @@ local HEAD_H = 20
 local PAD = 12
 
 local panel = nil
--- The rows actually drawn, capped by rowBudget, plus the "+N more" line.
+-- The rows actually drawn, capped by rowBudget, plus the "+N more" line. The
+-- producers' head rows are in here too and cost a slot each, because a section
+-- heading occupies a line on screen like anything else.
 local rows = {}
--- Everything due, including what did not fit. The header counts THIS: a panel
--- reading 13 while the tmux widget reads 20 makes both numbers worthless, and
--- an ADHD-facing count that understates the day is the one failure that matters.
-local total = 0
 
 -- Both tables belong to init.lua, which resets them on every load; the fallback
 -- is so this file still loads standalone (its own test does exactly that).
@@ -179,25 +203,26 @@ end
 -- ---------------------------------------------------------------------------
 
 local function styled()
-  -- Icon then count, the same shape and the same glyph as the tmux status
-  -- widget, so the number you glance at is in the same language on both.
-  local out = hs.styledtext.new(
-    string.format("%s  %d today\n", ICON, total),
-    { font = FONT, color = COLORS.head }
-  )
+  -- No header of its own. Every line here came from a producer, including the
+  -- head rows that name each section and carry its count.
+  --
   -- The reward state still has to fill the pane. Silence was right when this
   -- was a floating box that could just vanish; now that it holds a reserved
   -- strip, drawing nothing would leave a tall empty column that looks broken.
-  if total == 0 then
-    return out .. hs.styledtext.new("nothing due", { font = FONT, color = COLORS.head })
+  -- Reached only when NO producer said anything at all — a producer with an
+  -- empty list still prints its own header, and todoist prints "nothing due"
+  -- beneath it.
+  if #rows == 0 then
+    return hs.styledtext.new("nothing due", { font = FONT, color = COLORS.head })
   end
 
+  local out
   for _, row in ipairs(rows) do
-    out = out
-      .. hs.styledtext.new(row.text .. "\n", {
-        font = FONT,
-        color = COLORS[row.state] or COLORS.normal,
-      })
+    local piece = hs.styledtext.new(row.text .. "\n", {
+      font = FONT,
+      color = COLORS[row.state] or COLORS.normal,
+    })
+    out = out and out .. piece or piece
   end
   return out
 end
@@ -298,25 +323,36 @@ local function refresh()
   end
   retain.job = hs.task.new(DATA, function(_, stdout, _)
     rows = {}
-    total = 0
     local budget = rowBudget()
+    -- A count rather than the rows themselves, tallied as they overflow: the
+    -- alternative is subtracting #rows afterwards, which stops being true the
+    -- moment the "+N more" row below is appended to that same table.
+    local hidden = 0
+    local function want(row)
+      if #rows < budget then
+        rows[#rows + 1] = row
+      else
+        hidden = hidden + 1
+      end
+    end
     for line in (stdout or ""):gmatch("[^\n]+") do
       local state, text = line:match("^([^\t]*)\t(.*)$")
       if state then
-        total = total + 1
-        if #rows < budget then
-          rows[#rows + 1] = { state = state, text = text }
+        -- A head row after the first is the next producer's section starting:
+        -- give it a blank line first so two producers read as two lists, not
+        -- one. Routed through want() like any row — a short screen must still
+        -- count it in "+N more" rather than silently overrunning the frame.
+        if state == "head" and #rows > 0 then
+          want({ state = "blank", text = "" })
         end
+        want({ state = state, text = text })
       end
     end
-    -- A count rather than the rows themselves. Computed before the row is
-    -- appended, because appending changes #rows.
-    local hidden = total - #rows
     if hidden > 0 then
       rows[#rows + 1] = { state = "head", text = string.format("+%d more", hidden) }
     end
     render()
-  end)
+  end, DATA_ARGS)
   retain.job:start()
 end
 

--- a/modules/cli/todoist.nix
+++ b/modules/cli/todoist.nix
@@ -1209,6 +1209,22 @@ mkUserModule {
 
           [ -f "$CACHE" ] || exit 0
 
+          today=$(date +%F)
+
+          # The panel's header row, emitted by the producer rather than counted
+          # in the Lua. The panel concatenates every *-panel-data on the profile
+          # now, so a header the Lua summed itself would silently start counting
+          # linear issues as things "due today" and drift from the tmux widget.
+          # The count belongs where the today/sort definitions are.
+          n=$(jq -r --arg today "$today" '${unwrap} | ${dueToday} | length' "$CACHE" 2>/dev/null)
+          case "''${n:-}" in "" | *[!0-9]*) n=0 ;; esac
+          printf 'head\t%s  %s today\n' "$(printf '\uF0AE')" "$n"
+
+          # The reward state, also from here: at zero there are no rows to draw
+          # and a section that renders as a bare "0 today" reads like a failed
+          # fetch rather than a clear day.
+          [ "$n" -gt 0 ] || { printf 'head\tnothing due\n'; exit 0; }
+
           # state<TAB>text. The state NAMES a colour rather than carrying one,
           # so every judgement about what is urgent stays here beside the sort
           # that ordered it, and the Lua stays purely presentational.
@@ -1218,7 +1234,7 @@ mkUserModule {
           # is a bare date for an all-day task and a full datetime for a timed
           # one, and comparing those as strings is how a task due later today
           # gets dropped.
-          jq -r --arg today "$(date +%F)" '
+          jq -r --arg today "$today" '
             ${unwrap}
             | ${dueToday}
             | ${smartSort}

--- a/modules/dev/linear/linear.nix
+++ b/modules/dev/linear/linear.nix
@@ -38,6 +38,98 @@ let
       mainProgram = "linear-cli";
     };
   };
+
+  # The linear section of the ambient panel. That panel runs every
+  # *-panel-data on the profile and concatenates them, so appearing in it is
+  # only a matter of printing state<TAB>text — this module reaches into the
+  # surface, per the repo rule, and the todoist module that owns it stays
+  # unaware linear exists.
+  #
+  # In Progress / In Review / Todo only. Backlog is the majority of what is
+  # assigned to me and none of it is actionable today; an always-on panel that
+  # lists it trains you to stop reading the panel.
+  linear-panel-data = pkgs.writeShellApplication {
+    name = "linear-panel-data";
+    bashOptions = [ ];
+    runtimeInputs = [
+      linear-cli
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.gnugrep
+      pkgs.jq
+    ];
+    text = ''
+      CACHE="''${TMPDIR:-/tmp}/linear-panel.tsv"
+
+      # Detached refresh behind a cache, the same shape as todoist-panel-data:
+      # the panel is on its own 60s timer and re-reads shortly, so blocking on
+      # the Linear round trip here would only delay the rows it already has.
+      # Five minutes rather than todoist's two — an issue's state moves on a
+      # meeting's timescale, not a checkbox's.
+      if ! find "$CACHE" -mmin -5 2>/dev/null | grep -q .; then
+        (
+          tmp=$(mktemp) || exit 0
+          trap 'rm -f "$tmp"' EXIT
+
+          # Raw GraphQL rather than `i list`, and NOT for elegance: `i list`
+          # fetches ONE page and applies --filter to it client-side, so any
+          # issue past that page is invisible no matter what you filter for.
+          # That silently hid three Todos whose only crime was being old. The
+          # cure is a server-side filter, which is `--all` (every page, every
+          # refresh) or this — one request that returns only what is wanted.
+          #
+          # `viewer` is the authenticated user, so this also drops the separate
+          # whoami round trip and the display-name matching that --assignee
+          # needed.
+          #
+          # Filtering on state.TYPE, not state.name: type is Linear's own
+          # semantic grouping, so "started" is In Progress + In Review and
+          # "unstarted" is Todo, whatever a given team renamed its columns to.
+          # Matching English names would break on the first team that says
+          # "Doing" — and would have to be kept in sync by hand forever.
+          out=$(linear-cli api query '{ viewer { assignedIssues(first: 50, filter: { state: { type: { in: ["started","unstarted"] } } }) { nodes { identifier title priority state { name type } } } } }' \
+            --output json --no-pager --quiet 2>/dev/null \
+            | jq -r '
+                # Hard failure rather than an empty list: a GraphQL error also
+                # parses as "no issues", and writing that to the cache would
+                # replace a good list with a confident "0 active".
+                if (.data.viewer.assignedIssues.nodes | type) != "array" then
+                  error("no viewer in response")
+                else . end
+                | .data.viewer.assignedIssues.nodes
+                # Started before unstarted, then priority, then identifier for a
+                # stable order. Linear priority is 0=none 1=urgent..4=low, so the
+                # unset 0 has to be remapped to sort last instead of first.
+                | sort_by(
+                    (if .state.type == "started" then 0 else 1 end),
+                    (if (.priority // 0) == 0 then 5 else .priority end),
+                    .identifier
+                  )
+                | ["head", "linear  \(length) active"],
+                  (.[] | [ (if   .priority == 1 then "urgent"
+                            elif .priority == 2 then "medium"
+                            else "normal" end),
+                           "\(.identifier)  \(.title)" ])
+                | @tsv
+              ' 2>/dev/null)
+
+          # Empty means the fetch or the parse failed — the head row is
+          # unconditional, so even a day with nothing active produces output.
+          # Leaving the old cache in place keeps the last known list on screen
+          # instead of blanking the section on one bad network moment.
+          [ -n "$out" ] || exit 0
+
+          # Written aside and moved into place, like tmux-todoist-refresh: the
+          # panel reads this file on a timer and a half-written one would draw
+          # as a truncated list rather than as an error.
+          printf '%s\n' "$out" >"$tmp" && mv "$tmp" "$CACHE"
+        ) &
+      fi
+
+      [ -f "$CACHE" ] || exit 0
+      cat "$CACHE"
+    '';
+  };
 in
 mkUserModule {
   name = "linear";
@@ -45,13 +137,22 @@ mkUserModule {
 
   home =
     { userCfg, ... }:
+    let
+      # All three, because the surface is assembled from all three: todoist
+      # drops the panel Lua, hammerspoon draws it, and only then is there
+      # anything to run this producer.
+      panelEnabled = userCfg.todoist.enable && userCfg.todoist.panel.enable && userCfg.hammerspoon.enable;
+    in
     {
       home.packages = [
         linear-cli
         pkgs.gum
         pkgs.jq
         pkgs.pngpaste
-      ];
+      ]
+      # On the profile rather than referenced by store path: the panel discovers
+      # its producers by globbing ~/.nix-profile/bin/*-panel-data.
+      ++ lib.optionals panelEnabled [ linear-panel-data ];
 
       # Fish shell integration: lin CLI wrapper and helper functions
       programs.fish = lib.mkIf userCfg.fish.enable {


### PR DESCRIPTION
Linear issues now sit in the always-on panel, under today's Todoist list.

```
  8 today
! Assess and finish research playbook
! Terminology System Phase 1 RFC
...
Finish GraphQL API Gateway RFC

linear  3 active
ENG-5382  Create unified dashboard
ENG-5723  Use existing invitation when signup is independent
ENG-6050  Fix voice editing generation for real time medical record
```

## The panel grew a plugin protocol

It ran exactly one producer and synthesised its own `N today` header from
the rows it got back. That header was the thing in the way: summed in the
Lua, it would count a second producer's rows as things due today and drift
from the count in the tmux bar. Two numbers that disagree are worse than no
number.

So the count moved to where its definition already lives. Each producer
prints its own head row — `todoist-panel-data` reading the same cache and
the same today/sort rules as the widget — and the panel draws what it is
handed.

That is the whole protocol: the panel runs every `*-panel-data` on the
profile, so a module with something worth seeing all day drops an
executable with that suffix and appears, without either side learning the
other's name. Todoist is not a guest in its own panel and always leads;
guests follow in glob order, each behind a blank line.

The separator goes through the same row budget as any row, so a short
screen still counts it in `+N more` rather than drawing past the bottom of
the frame.

## Why raw GraphQL and not `linear-cli i list`

`i list` fetches **one page** and applies `--filter` to it client-side, so
an issue past that page is invisible no matter what you filter for. It
silently hid three Todos whose only crime was being old:

```
$ linear-cli i list --assignee "Fernando Silva" --filter "state.name=Todo"
(nothing)

$ linear-cli i list --assignee "Fernando Silva" --filter "state.name=Todo" --all
count=3
```

A server-side filter is either `--all`, paying for every page on every
refresh, or one request that asks for exactly what it wants. Using `viewer`
also drops the separate `whoami` round trip and the display-name matching
`--assignee` needed.

The filter is on `state.type`, not `state.name`. Type is Linear's own
grouping — `started` is In Progress + In Review, `unstarted` is Todo —
so it survives a team renaming its columns. Matching English names would
break on the first team that says "Doing", in exactly the same silent way
this bug did.

`jq` errors when the response carries no viewer, so a GraphQL failure
leaves the last good list on screen instead of overwriting it with a
confident `0 active`.

## Notes

- Auth stays inside `linear-cli`; nothing secret enters the nix store.
- Cached 5 minutes, refreshed detached, so the panel never blocks on the network.
- `linear-panel-data` only lands on the profile when todoist's panel and hammerspoon are both enabled.

## Verification

- Panel spec 28/28 (`nvim -l modules/cli/todoist-panel-test.lua`), including a new case for two producers sharing one budget and the separator's exact position.
- `nix flake check` — all checks passed (byte-compiles the generated Lua and re-runs the spec against the installed file).
- `statix check .`, `nixfmt`, `nix build` clean; shellcheck runs on both producers at build time.
- jq edge cases exercised by hand: GraphQL error response, non-JSON, genuinely-zero, mixed started/unstarted priority ordering.
- Ordering proven with stand-in producers, including one that sorts alphabetically ahead of todoist — todoist still leads.
- Ran live on vega after `darwin-rebuild switch`; output above is the real stream.