### PR TITLE
fix(todoist): show every task that fits, and stop clicks falling through the panel

### DIFF
--- a/modules/cli/todoist-panel-test.lua
+++ b/modules/cli/todoist-panel-test.lua
@@ -48,6 +48,12 @@ local canvas = setmetatable({}, {
         return s
       end
     end
+    if k == "mouseCallback" or k == "clickActivating" then
+      return function(s, v)
+        calls[k] = v
+        return s
+      end
+    end
     if k == "frame" then
       return function(s, f)
         if f then
@@ -553,6 +559,23 @@ check("background is solid and square, not a translucent rounded widget", functi
     "background must be opaque, got alpha " .. tostring(bg.fillColor.alpha)
   )
   assert(bg.roundedRectRadii == nil, "a terminal pane has square corners")
+end)
+
+-- Locks a two-line fix that looks like dead code. The empty callback IS the
+-- mechanism: hs.canvas keeps ignoresMouseEvents on until one is registered, so
+-- deleting it as pointless puts the click back on the Finder desktop and sends
+-- every window away again.
+check("clicks are swallowed, not passed through to the desktop", function()
+  load_with(rowsOf(3))
+  assert(
+    type(calls.mouseCallback) == "function",
+    "a registered mouseCallback is what clears ignoresMouseEvents; got "
+      .. type(calls.mouseCallback)
+  )
+  assert(
+    calls.clickActivating == false,
+    "clickActivating defaults to TRUE -- unset, a stray click pulls Hammerspoon to the front"
+  )
 end)
 
 check("every line uses the terminal's own monospace font", function()

--- a/modules/cli/todoist-panel-test.lua
+++ b/modules/cli/todoist-panel-test.lua
@@ -224,10 +224,10 @@ local function rowsOf(n, state)
   return table.concat(t, "\n")
 end
 
--- Drives the SCREEN rather than overriding maxTasks. The installed file carries
--- a nix-generated `_G.__todoistPanelCfg` prelude that reassigns maxTasks on
--- every load, so a test that set it would pass locally against the bare source
--- and prove nothing about the file actually shipped.
+-- Drives the SCREEN, which is the panel's only row bound. The installed file
+-- carries a nix-generated `_G.__todoistPanelCfg` prelude that reassigns config
+-- on every load, so a test that set config directly would pass locally against
+-- the bare source and prove nothing about the file actually shipped.
 local function withScreen(h, fn)
   local saved = SCREEN
   SCREEN = { x = 0, y = 25, w = 1440, h = h }
@@ -243,7 +243,6 @@ end
 load_with(rowsOf(1))
 local cfg = _G.__todoistPanelCfg or {}
 local WIDTH = cfg.width or 300
-local MAX = cfg.maxTasks or 12
 
 -- The panel is full-height now, so its frame says nothing about how many rows
 -- it drew. Everything below counts STYLED RUNS instead: one per row it was
@@ -256,6 +255,14 @@ end
 
 local function rowText(i)
   return captured[i].s
+end
+
+-- The row budget the panel computes for whatever SCREEN is in effect, MEASURED
+-- by overflowing it rather than recomputed from the row height. A copy of the
+-- formula here would keep agreeing with itself after the panel's changed.
+local function budget()
+  load_with(rowsOf(500))
+  return drawnRows() - 1
 end
 
 -- ---------------------------------------------------------------------------
@@ -328,15 +335,16 @@ end)
 -- the screen, where the rows cannot be read and are not counted either.
 check("two producers share one pane, one budget and one +N more", function()
   withScreen(4000, function()
+    local fits = budget()
     load_with(
       "head\tlinear  2 active\nnormal\tENG-1  a\nnormal\tENG-2  b\n"
         .. "head\t\239\130\174  20 today\n"
-        .. rowsOf(MAX)
+        .. rowsOf(fits)
     )
     local t = text()
     assert(t:find("linear  2 active", 1, true), "the linear section should be drawn")
     assert(t:find("20 today", 1, true), "the todoist section should be drawn")
-    assert(drawnRows() == MAX + 1, "budget is shared across sections, drew " .. drawnRows())
+    assert(drawnRows() == fits + 1, "budget is shared across sections, drew " .. drawnRows())
     assert(t:find("%+5 more"), "overflow across both sections must be counted, got:\n" .. t)
     -- The separator itself: a blank line, costing a budget slot like any row,
     -- between the last linear row and the second section's head.
@@ -346,42 +354,54 @@ check("two producers share one pane, one budget and one +N more", function()
 end)
 
 check("overflow collapses into a +N more row", function()
-  load_with(rowsOf(MAX + 8))
+  local fits = budget()
+  load_with(rowsOf(fits + 8))
   local t = text()
   assert(t:find("%+8 more"), "expected '+8 more', got:\n" .. t)
-  assert(t:find("task " .. MAX, 1, true), "row " .. MAX .. " should be present")
-  assert(not t:find("task " .. (MAX + 1), 1, true), "row " .. (MAX + 1) .. " should be capped out")
-  assert(drawnRows() == MAX + 1, "should draw maxTasks rows plus the +N line, drew " .. drawnRows())
+  assert(t:find("task " .. fits .. "\n", 1, true), "row " .. fits .. " should be present")
+  assert(
+    not t:find("task " .. (fits + 1) .. "\n", 1, true),
+    "row " .. (fits + 1) .. " should be capped out"
+  )
+  assert(drawnRows() == fits + 1, "should draw the budget plus the +N line, drew " .. drawnRows())
 end)
 
--- The regression these two exist for: at the default maxTasks the panel is far
--- shorter than any normal screen, so a broken bound stays invisible until
--- someone raises the option or docks to a small display.
-check("a screen too short for maxTasks rows still fits, and says so", function()
+-- The regression these two exist for: the screen is now the ONLY bound, so a
+-- broken height computation shows up nowhere except as rows painted past the
+-- bottom edge, where they cannot be read and are not counted either.
+check("a screen too short for the list still fits, and says so", function()
+  local tall
+  withScreen(4000, function()
+    tall = budget()
+  end)
   withScreen(200, function()
     load_with(rowsOf(500))
     local f = lastFrame()
     assert(f.h == 200, "panel should still be exactly full height, got " .. f.h)
     -- Stated as a comparison against the roomy case rather than against a row
     -- height copied from the panel: if the budget ignored screen height, this
-    -- short pane would draw the same maxTasks rows as a 4000pt one and run them
-    -- straight off the bottom, where they cannot be read.
+    -- short pane would draw the same rows as a 4000pt one and run them straight
+    -- off the bottom, where they cannot be read.
     assert(
-      drawnRows() < MAX + 1,
+      drawnRows() < tall + 1,
       "a 200pt pane drew " .. drawnRows() .. " rows, same as a tall one -- they overflow"
     )
     assert(text():find("%+%d+ more"), "rows dropped for space must still be counted")
   end)
 end)
 
-check("a screen with room to spare is bounded by maxTasks", function()
-  withScreen(4000, function()
-    load_with(rowsOf(500))
-    assert(
-      drawnRows() == MAX + 1,
-      "should stop at maxTasks(" .. MAX .. ") + the +N row, drew " .. drawnRows()
-    )
+-- The other half, and the one the "+1 more on a half-empty screen" bug lived
+-- in: a taller screen has to actually USE the room. A fixed cap on top of the
+-- screen bound passes the check above and still fails this one.
+check("a taller screen draws more rows, so no fixed cap outranks it", function()
+  local short, tall
+  withScreen(400, function()
+    short = budget()
   end)
+  withScreen(4000, function()
+    tall = budget()
+  end)
+  assert(tall > short, "4000pt drew " .. tall .. " rows, 400pt drew " .. short .. " -- capped")
 end)
 
 -- Relationships, not thresholds: "red is redder than it is green" survives a

--- a/modules/cli/todoist-panel.lua
+++ b/modules/cli/todoist-panel.lua
@@ -250,8 +250,23 @@ local function render()
     -- canJoinAllSpaces so switching Spaces does not take the list away;
     -- stationary so Mission Control leaves it where it is.
     panel:behavior({ "canJoinAllSpaces", "stationary" })
-    -- No mouseCallback anywhere in this file, which is what keeps the canvas
-    -- click-through: hs.canvas sets ignoresMouseEvents until one is registered.
+    -- Swallow clicks. hs.canvas leaves ignoresMouseEvents on until a
+    -- mouseCallback is registered, so without these two lines a click aimed at
+    -- the panel lands on the Finder desktop behind it and sends every window
+    -- away. Nothing is lost by absorbing it: the panel holds a RESERVED strip,
+    -- so the desktop is the only thing back there.
+    --
+    -- The callback is deliberately empty. Read-only is the design (see the top
+    -- of this file) — this stops the misfire, it does not add a surface to
+    -- fiddle with. Making ROWS clickable is a different change: every row is
+    -- one line inside a single text element, so each would have to become its
+    -- own canvas element with its own frame before a click could name one.
+    --
+    -- clickActivating(false) is the half that keeps this invisible: it defaults
+    -- to TRUE, and left alone a stray click would pull Hammerspoon to the front
+    -- and steal focus from whatever is being typed in.
+    panel:clickActivating(false)
+    panel:mouseCallback(function() end)
     -- Square, not rounded. Rounded corners read as a floating widget; this is
     -- a pane sitting in its own strip, and terminals do not have rounded panes.
     panel[1] = {

--- a/modules/cli/todoist-panel.lua
+++ b/modules/cli/todoist-panel.lua
@@ -39,7 +39,6 @@ local retain = _G.__todoistPanelRetain
 
 local cfg = _G.__todoistPanelCfg or {}
 local WIDTH = cfg.width or 300
-local MAX = cfg.maxTasks or 12
 local SCREEN = cfg.screen
 local EVERY = cfg.refresh or 60
 
@@ -146,9 +145,15 @@ local function reserve()
     or nil
 end
 
--- How many rows fit on the target screen. maxTasks is the ceiling, but a short
--- screen outranks it: a row drawn past the bottom edge is a row that is not
--- there, and it has to be counted in "+N more" rather than silently lost.
+-- How many rows fit on the target screen — the ONLY bound. A row drawn past the
+-- bottom edge is a row that is not there, so it has to be counted in "+N more"
+-- rather than silently lost.
+--
+-- There used to be a maxTasks option capping this further, and it was the thing
+-- collapsing rows into "+N more" on a screen with room for forty more. A second
+-- smaller cap cannot make the list safer than the screen bound already does; it
+-- can only hide work. An ambient panel earns its strip by showing everything
+-- that fits, so the strip is the limit.
 --
 -- One rule instead of two. Clamping the panel HEIGHT to the screen was the
 -- obvious alternative and is worse — it produces a box the right size with rows
@@ -160,15 +165,15 @@ end
 -- fifty, and this way the height is provably <= the screen by construction.
 local function rowBudget()
   local screen = targetScreen()
+  -- No display attached at all: render() draws nothing either way, so bound
+  -- nothing rather than inventing a number and reporting rows as hidden. The
+  -- next tick, with a screen, computes a real budget.
   if not screen then
-    return MAX
+    return math.huge
   end
   local fits = math.floor((screen:frame().h - (PAD * 2) - HEAD_H) / ROW_H) - 1
   if fits < 1 then
     fits = 1
-  end
-  if fits > MAX then
-    fits = MAX
   end
   return fits
 end

--- a/modules/cli/todoist.nix
+++ b/modules/cli/todoist.nix
@@ -66,16 +66,6 @@ mkUserModule {
         description = "Panel width in points.";
       };
 
-      maxTasks = lib.mkOption {
-        type = lib.types.int;
-        default = 12;
-        description = ''
-          Rows to draw before collapsing the rest into a "+N more" line. The cap
-          is what keeps the list shorter than the screen — a panel that runs off
-          the bottom hides the overdue rows the sort worked to put at the top.
-        '';
-      };
-
       screen = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = null;
@@ -1428,7 +1418,6 @@ mkUserModule {
         text = ''
           _G.__todoistPanelCfg = {
             width = ${toString cfg.panel.width},
-            maxTasks = ${toString cfg.panel.maxTasks},
             screen = ${if cfg.panel.screen == null then "nil" else ''"${cfg.panel.screen}"''},
           }
         ''


### PR DESCRIPTION
Two fixes to the ambient panel, one commit each.

## Show every task that fits (40c4a0f)

The panel bounded its list twice: `rowBudget` works out how many rows fit on the screen, and a `maxTasks` option capped that at 12 on top. The screen bound is the one that matters — a row drawn past the bottom edge cannot be read — and the cap could only ever hide rows the screen had room for.

Which it did, once a second producer appeared. Seven Todoist rows, their header, a blank separator and four Linear rows is 13, so the last Linear issue collapsed into `+1 more` on a display with room for 58.

The cap is gone, and `maxTasks` with it — nothing set it, and a second smaller limit cannot make the list safer than the screen bound already does.

Measured against the live producers, same fixture, same panel code:

| screen | drawn |
|---|---|
| 270pt (a budget of 12, the old cap) | `+1 more` |
| 957pt (built-in) | all 13 rows, 3/3 Linear |
| 1055pt (external) | all 13 rows, 3/3 Linear |

## Swallow clicks on the panel (715a69e)

`hs.canvas` leaves `ignoresMouseEvents` on until a `mouseCallback` is registered, and the panel deliberately never registered one. So a click landing on the panel went through to the Finder desktop, which sends every window away — easy to trigger on a strip parked down the edge of a screen.

An empty callback is the whole fix. Absorbing the click costs nothing, because the panel holds a reserved strip and the desktop is the only thing behind it. `clickActivating(false)` is the other half: it defaults to `true`, so left alone the first click would pull Hammerspoon to the front and steal focus.

Read-only stays the design — this stops the accident, it does not add a surface to fiddle with. Making rows clickable is a different change: every row is one line inside a single `text` element, so each would need its own canvas element before a click could name one.

## Checks

29 pass (`nix flake check`, which runs them against the installed file, prelude and all). Both new locks were confirmed to fail without their fix rather than pass vacuously:

- strip the two mouse lines → `clicks are swallowed` fails
- reintroduce a fixed cap → `a taller screen draws more rows` fails

The two checks that asserted `maxTasks` now measure the budget by overflowing it instead of reading the option.