### PR TITLE
chore(opencode): update to 1.18.29 for gpt-6-astra

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,16 +518,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1788385242,
-        "narHash": "sha256-whpu6YnWe82VXYzHib22OZx/TAlzSWi2D7HAW+1GMII=",
+        "lastModified": 1788565620,
+        "narHash": "sha256-lCXlxTOhcX70jxJAbpolyGlIxQK2nst+6bFhq3Xzdmc=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "4b7e19e315cca414121ba1d61523fef74bb3ae8b",
+        "rev": "16747470f976aca3d362ad730bcd3fe82ecc2c9a",
         "type": "github"
       },
       "original": {
         "owner": "anomalyco",
-        "ref": "v1.18.27",
+        "ref": "v1.18.29",
         "repo": "opencode",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
     };
 
     opencode = {
-      url = "github:anomalyco/opencode/v1.18.27";
+      url = "github:anomalyco/opencode/v1.18.29";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
`gpt-6-astra` shipped on the ChatGPT/Codex backend, but opencode's oauth model filter matched ids against `/^gpt-(\d+\.\d+)/` and compared them with `parseFloat`, so a version with no minor component never matched and the model was dropped before it ever reached the picker.

1.18.29 fixes it (anomalyco/opencode#47384, anomalyco/opencode#47385):

```diff
- const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
- return match ? parseFloat(match[1]) > 5.4 : false
+ const match = model.api.id.match(/^gpt-(\d+)(?:\.(\d+))?/)
+ if (!match) return false
+ const major = Number(match[1])
+ const minor = Number(match[2] ?? 0)
+ return major > 5 || (major === 5 && minor > 4)
```

That also un-breaks `gpt-5.10` and later, where `parseFloat` read `"5.10"` as `5.1` and sorted it under the 5.4 cutoff.

models.dev added the entry at the same time, so the model arrives with its real limits and a `-fast` variant alongside.

## Verification

- `opencode models openai` with **no config at all**: 1.18.29 lists `openai/gpt-6-astra` and `openai/gpt-6-astra-fast`; 1.18.27 lists neither.
- Resolved model: `reasoning: true`, `limit.context: 1050000`, variants `low`/`medium`/`high`/`xhigh`/`max`.
- End-to-end `opencode run -m openai/gpt-6-astra` returns a response over the Codex oauth backend.
- `nix build .#darwinConfigurations.vega.system` succeeds — the three opencode patches still apply against 1.18.29.
- `darwin-rebuild switch` clean, no activation errors.
