### PR TITLE
fix(opencode): stop omo bouncing gpt-6-astra from Sisyphus to Hephaestus

### DIFF
--- a/modules/dev/opencode/omo.nix
+++ b/modules/dev/opencode/omo.nix
@@ -1,7 +1,13 @@
 { pkgs }:
 let
   jsonFormat = pkgs.formats.json { };
-  plugin = "oh-my-openagent@4.19.4";
+  package = "oh-my-openagent";
+  version = "4.19.4";
+  plugin = "${package}@${version}";
+
+  # opencode npm-installs its own plugins at runtime, so there is no
+  # derivation to hang `applyPatches` off — the tree lands here instead.
+  pkgRoot = "$HOME/.cache/opencode/packages/${plugin}/node_modules/${package}";
 in
 {
   default = true;
@@ -10,6 +16,26 @@ in
     programs.opencode = {
       settings.plugin = [ plugin ];
       tui.plugin = [ plugin ];
+    };
+
+    # Backport of upstream 0fe0ac98 ("route categories through GPT-6 Astra
+    # high"), which shipped in 5.0.0-beta.43 but never in the 4.x line.
+    # Without it omo's `no-sisyphus-gpt` hook treats every gpt-* model that
+    # isn't gpt-5.x as unsupported and force-switches Sisyphus → Hephaestus,
+    # so each gpt-6-astra turn gets hijacked. The patch also routes gpt-6 to
+    # the gpt-5-5 prompt family and defaults its variant to high, matching
+    # upstream. Drop the whole block once the pin above reaches 5.x.
+    home.activation.omoGpt6Sisyphus = {
+      after = [ "writeBoundary" ];
+      before = [ ];
+      data = ''
+        omo_index="${pkgRoot}/dist/index.js"
+        if [ ! -f "$omo_index" ]; then
+          echo "omo: ${plugin} not installed yet — GPT-6 patch applies on the next rebuild"
+        elif ! grep -q 'function isGpt6Model' "$omo_index"; then
+          ${pkgs.gnupatch}/bin/patch -p1 -d "${pkgRoot}" < ${./patches/omo-gpt6-sisyphus.patch}
+        fi
+      '';
     };
 
     # Plugin-registered agent overrides live here rather than in

--- a/modules/dev/opencode/patches/omo-gpt6-sisyphus.patch
+++ b/modules/dev/opencode/patches/omo-gpt6-sisyphus.patch
@@ -1,0 +1,56 @@
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -28147,6 +28147,10 @@
+   const modelName = extractModelName2(model).toLowerCase();
+   return modelName.includes("gpt-5.6") || modelName.includes("gpt-5-6");
+ }
++function isGpt6Model(model) {
++  const modelName = extractModelName2(model).toLowerCase();
++  return modelName.includes("gpt-6");
++}
+ 
+ // packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
+ var ULTRABRAIN_CATEGORY_PROMPT_APPEND = `<Category_Context>
+@@ -107385,6 +107389,8 @@
+ function getNativeSisyphusGptVariant(model) {
+   if (isGpt5_5Model(model.modelID))
+     return "medium";
++  if (isGpt6Model(model.modelID))
++    return "high";
+   const chain = AGENT_MODEL_REQUIREMENTS["sisyphus"]?.fallbackChain ?? [];
+   const exactMatch = chain.find((entry) => entry.providers.includes(model.providerID) && entry.model === model.modelID);
+   if (exactMatch?.variant !== undefined) {
+@@ -107398,13 +107404,13 @@
+       const rawAgent = input.agent ?? getSessionAgent(input.sessionID) ?? "";
+       const agentKey = getAgentConfigKey(rawAgent);
+       const modelID = input.model?.modelID;
+-      if (agentKey === "sisyphus" && input.model && modelID && isGptNativeSisyphusModel(modelID) && output?.message && output.message.variant === undefined) {
++      if (agentKey === "sisyphus" && input.model && modelID && (isGptNativeSisyphusModel(modelID) || isGpt6Model(modelID)) && output?.message && output.message.variant === undefined) {
+         const variant = getNativeSisyphusGptVariant(input.model);
+         if (variant !== undefined) {
+           output.message.variant = variant;
+         }
+       }
+-      if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID)) {
++      if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID) && !isGpt6Model(modelID)) {
+         showToast(ctx, input.sessionID);
+         input.agent = resolveRegisteredAgentName("hephaestus") ?? "hephaestus";
+         if (output?.message) {
+@@ -156515,7 +156521,7 @@
+     return "kimi-k2-7";
+   if (isKimiK2Model(model))
+     return "kimi-k2-6";
+-  if (isGpt5_5Model(model) || isGpt5_6Model(model))
++  if (isGpt5_5Model(model) || isGpt5_6Model(model) || isGpt6Model(model))
+     return "gpt-5-5";
+   if (isGptNativeSisyphusModel(model))
+     return "gpt-5-4";
+@@ -160878,7 +160884,7 @@
+   if (model && isKimiK2Model(model))
+     return "kimi-k2";
+   if (model && isGptModel(model)) {
+-    if (isGpt5_5Model(model) || isGpt5_6Model(model))
++    if (isGpt5_5Model(model) || isGpt5_6Model(model) || isGpt6Model(model))
+       return "gpt-5-5";
+     const lower = model.toLowerCase();
+     if (lower.includes("gpt-5.4") || lower.includes("gpt-5-4"))


### PR DESCRIPTION
Selecting `gpt-6-astra` silently moved every turn to **Hephaestus - Deep Agent**, no matter which agent was chosen.

## Cause

omo's `no-sisyphus-gpt` hook force-switches Sisyphus to Hephaestus for any GPT model it does not recognise:

```js
if (agentKey === "sisyphus" && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID)) {
  input.agent = "hephaestus";
}
```

`isGptModel` is a bare `includes("gpt")`, while the allowlist is a gpt-5-only regex — `/gpt-5[.-](?:(?:3[.-])?codex|[4-9]|\d{2,})/i`. So `gpt-6-astra` reads as "a GPT model Sisyphus cannot handle" and gets bounced, which started biting as soon as #647 pinned the opencode release that makes the model selectable.

| model | `isGptModel` | allowlisted | before |
|---|---|---|---|
| `gpt-6-astra` | true | **false** | hijacked |
| `gpt-6-astra-fast` | true | **false** | hijacked |
| `gpt-5.6-sol` | true | true | fine |
| `gpt-5-codex` | true | true | fine |

## Fix

Upstream solved it in [code-yeongyu/oh-my-openagent@0fe0ac98](https://github.com/code-yeongyu/oh-my-openagent/commit/0fe0ac98fc881827bfcf5bdb755b3f8264a761ca) by adding `isGpt6Model` next to the regex rather than widening it. That shipped in `5.0.0-beta.43` only — the 4.x line, which npm `latest` still points at, never received it.

This backports the five hunks onto the pinned 4.19.4 bundle.

opencode npm-installs its own plugins at runtime, so unlike `direnv-plugin` and `anthropic-auth` there is no derivation to hang `applyPatches` off — the tree lands in `~/.cache/opencode/packages/<spec>/` with its own ~200-package dependency tree. An activation script patches it in place instead, guarded by a `grep -q 'function isGpt6Model'` so it is a no-op once applied and self-heals if the cache is ever rebuilt.

The two prompt-family hunks come along too, so gpt-6 gets the `gpt-5-5` Sisyphus prompt and variant `high`. Disabling the hook via `disabled_hooks` would have fixed the routing but dropped the prompt to the generic fallback.

## Verification

- Patch applies clean to a pristine `oh-my-openagent@4.19.4` tarball pulled fresh from npm, not just the local install
- Re-running the activation script is a no-op
- Patched bundle still parses (bun)
- Guard predicates extracted from the shipped bundle and executed: gpt-6 variants stay on Sisyphus, `gpt-4o` is still correctly routed to Hephaestus, Claude untouched
- End to end, in a real process:

```
$ opencode run --agent sisyphus --model openai/gpt-6-astra "Reply with exactly: PONG"
stream providerID=openai modelID=gpt-6-astra agent="Sisyphus - ultraworker" mode=primary
PONG
```

The block carries a comment to delete it once the pin reaches 5.x.
