### PR TITLE
feat(antiburn): track agent token burn, and add codex for its limits

### DIFF
--- a/modules/dev/antiburn.nix
+++ b/modules/dev/antiburn.nix
@@ -1,0 +1,44 @@
+{
+  mkUserModule,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  antiburn = pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "antiburn";
+    version = "0.3.3";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/antiburn/antiburn/releases/download/antiburn-v${finalAttrs.version}/antiburn_${finalAttrs.version}_aarch64.app.tar.gz";
+      hash = "sha256-gPUcsXluc2Diyz5/BknUMm+gjmNCegxlZFNnW4W9akM=";
+    };
+
+    sourceRoot = ".";
+
+    # Tauri ships a hardened-runtime signed bundle — strip/patchelf would
+    # invalidate the signature and macOS would refuse to launch it.
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r antiburn.app $out/Applications
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Local-first visibility into your AI coding-agent sessions";
+      homepage = "https://antiburn.ai/";
+      license = lib.licenses.mit;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      platforms = [ "aarch64-darwin" ];
+    };
+  });
+in
+mkUserModule {
+  name = "antiburn";
+  home.home.packages = [ antiburn ];
+}

--- a/modules/dev/codex.nix
+++ b/modules/dev/codex.nix
@@ -1,0 +1,5 @@
+{ mkUserModule, pkgs, ... }:
+mkUserModule {
+  name = "codex";
+  home.home.packages = with pkgs; [ codex ];
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -41,6 +41,7 @@ mkUser {
   doppler.enable = true;
   claude.enable = true;
   "claude-code".enable = true;
+  codex.enable = true;
   opencode = {
     enable = true;
     server.autoAttach = false;
@@ -48,6 +49,7 @@ mkUser {
   openclaw.enable = true;
   playwright-cli.enable = true;
   opencode-manager.enable = true;
+  antiburn.enable = true;
   # rtk.enable = true;
   ollama.enable = true;
   # hermes.enable = true;


### PR DESCRIPTION
Adds two modules to vega.

## antiburn

[antiburn](https://github.com/antiburn/antiburn) reads coding-agent sessions already on disk — Claude Code, Codex, Cursor, OpenCode, Cline, Amp, Antigravity, Pi — and shows activity, cost estimates and provider rate limits. Local-first: no account, no backend.

No Homebrew cask exists upstream, so the module follows the existing `paisa.nix` pattern — fetch the signed `aarch64.app.tar.gz` from GitHub Releases, copy the bundle into `$out/Applications`.

`dontFixup = true` is load-bearing: the bundle ships a hardened-runtime signature that nix's default `fixupPhase` strip would invalidate. Verified with `spctl -a -vv`, which reports `accepted`, `source=Notarized Developer ID`, `origin=Developer ID Application: Cadence AI (Vic) Pty Ltd (JCK9YYRR88)`.

Upgrades are manual — the store path is read-only so antiburn's own updater cannot run. Bump `version` + `hash`.

## codex

`pkgs.codex` 0.118.0. antiburn reads Codex rate limits two ways, and both need the CLI on disk:

1. spawns `codex app-server`, calls `account/rateLimits/read` over JSON-RPC
2. falls back to `~/.codex/auth.json` and the `chatgpt.com/backend-api/wham/usage` endpoint

Claude Code needs nothing extra — antiburn reads the `Claude Code-credentials` keychain item and calls `api.anthropic.com/api/oauth/usage` itself.

## Verification

- `statix check .` clean, `nixfmt` clean
- flake evaluates, both derivations build
- `codex --version` reports `codex-cli 0.118.0`; `codex app-server --help` works
- antiburn bundle passes Gatekeeper

Post-merge: run `codex login` before antiburn can read Codex limits.
