### PR TITLE
fix(tmux): read the core count with getconf so the CPU widget works on Linux

### DIFF
--- a/modules/cli/tmux/statusbar.nix
+++ b/modules/cli/tmux/statusbar.nix
@@ -20,7 +20,12 @@ let
       # ponytail: was vm.loadavg/ncpu, but macOS load counts threads that aren't
       # running, so it pinned at 100% with the CPU 70% idle. ps pcpu is a
       # decaying per-process average — close enough for a status bar.
-      ncpu=$(sysctl -n hw.ncpu 2>/dev/null)
+      # getconf, not `sysctl -n hw.ncpu`: that spelling is macOS-only and on
+      # Linux fell into the ''${ncpu:-1} fallback, dividing by 1 core instead of
+      # 32 and pinning the widget at 100% again. getconf is correct on both.
+      # ponytail: Linux ps pcpu is a lifetime average, not a decaying one, so
+      # short spikes under-report. /proc/stat deltas if that ever matters.
+      ncpu=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
       cpu=$(ps -Ao pcpu 2>/dev/null | awk -v n="''${ncpu:-1}" 'NR > 1 { s += $1 } END { v = s / n; printf "%.0f", (v > 100 ? 100 : v) }')
       [[ -z "''${cpu}" ]] && exit 0
 


### PR DESCRIPTION
The status bar CPU widget sat between 60% and a pinned red 100% on polaris while the machine was idle. `/proc/stat` put actual usage at ~2% and `/proc/pressure/cpu` reported zero contention.

## Cause

The divisor was missing. `sysctl -n hw.ncpu` is the macOS spelling — Linux `sysctl` reads `/proc/sys`, so it looked for `/proc/sys/hw/ncpu`, failed, and the `2>/dev/null` on that line swallowed the error. `ncpu` came back empty and awk fell into the `${ncpu:-1}` fallback, dividing the summed per-process CPU by **one core instead of 32**.

So the widget was rendering a 32-core sum against a single core: anything above ~3% real load showed as red.

## Fix

`getconf _NPROCESSORS_ONLN` answers the same question on both platforms and costs 1ms, so the macOS path is unchanged and there is no need to branch on the host.

## Measured

Against the built widget, idle machine:

| | reads |
|---|---|
| `sysctl` path (before) | **60%** orange — 100% red under any load |
| `getconf` path (after) | **2%** green |
| `/proc/stat` ground truth | **~2%** |

## Checks

- `statix check .` clean
- `nixfmt --check` clean
- `nix flake check` all checks passed
- `statusbar.test.sh` 9/9 (disk widget, unaffected)
- built the derivation and ran the real binary, not just the extracted body

## Known ceiling, marked in place

On Linux `ps -o pcpu` is a lifetime average rather than the decaying average macOS gives, so brief spikes under-report. `/proc/stat` deltas against a state file would fix it if that ever matters; at a 5s interval it has not. The widget costs 8ms per tick either way — ~0.16% of one core.

This is the second time this widget has pinned at 100% for a platform-assumption reason (the previous being macOS load average counting non-running threads), so the comment now names both.