### PR TITLE
feat(polaris): add sshd, tailscale and a headless server mode

### DIFF
--- a/modules/cli/ssh.nix
+++ b/modules/cli/ssh.nix
@@ -1,6 +1,27 @@
-{ mkUserModule, forPlatform, ... }:
+{
+  mkUserModule,
+  forPlatform,
+  lib,
+  ...
+}:
 mkUserModule {
   name = "ssh";
+
+  extraOptions.authorizedKeys = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    description = "Public keys accepted for SSH login as this user.";
+  };
+
+  # linux only: on darwin the daemon is toggled ad hoc by tmux-remote and the
+  # keys are handed out by the 1Password agent, so there is no declarative
+  # authorized_keys to own there. forPlatform yields {} on darwin.
+  user =
+    { cfg, ... }:
+    forPlatform {
+      linux.openssh.authorizedKeys.keys = cfg.authorizedKeys;
+    };
+
   system.programs.ssh = {
     extraConfig = ''
       Host *

--- a/modules/linux/server-mode.nix
+++ b/modules/linux/server-mode.nix
@@ -1,0 +1,55 @@
+# server-mode — park the machine as a headless box.
+#
+# The idle cost worth cutting is the desktop session itself: niri plus the
+# noctalia shell keep the 5070 Ti out of its deep idle states and hold the
+# monitor awake. sshd and tailscale live in multi-user.target, so stopping
+# the display manager never touches remote access.
+#
+# `display-manager.service` rather than `greetd.service`: that alias is set
+# by the greetd module itself, so this keeps working if the greeter is ever
+# swapped.
+#
+# Deliberately NOT `systemctl isolate multi-user.target` — isolate is not
+# guaranteed to spare the SSH session that issued it, and it frees the same
+# watts. Needs root, so it is `sudo server-mode on` over SSH.
+{ mkSystemModule, pkgs, ... }:
+let
+  server-mode = pkgs.writeShellApplication {
+    name = "server-mode";
+    runtimeInputs = [ pkgs.systemd ];
+    text = ''
+      case "''${1:-status}" in
+        on)
+          systemctl stop display-manager.service
+          echo "server mode on — desktop stopped"
+          ;;
+        off)
+          systemctl start display-manager.service
+          echo "server mode off — desktop started"
+          ;;
+        status)
+          if systemctl is-active --quiet display-manager.service; then
+            echo "off — desktop running"
+          else
+            echo "on — headless"
+          fi
+          ;;
+        *)
+          echo "usage: server-mode on|off|status" >&2
+          exit 1
+          ;;
+      esac
+    '';
+  };
+in
+mkSystemModule {
+  name = "server-mode";
+  config = {
+    environment.systemPackages = [ server-mode ];
+
+    # Blank the text console after a minute so the monitor reaches DPMS off
+    # once the session is down. Only affects the VT — a Wayland session owns
+    # the display otherwise, so normal desktop use is unchanged.
+    boot.kernelParams = [ "consoleblank=60" ];
+  };
+}

--- a/modules/networking/tailscale.nix
+++ b/modules/networking/tailscale.nix
@@ -1,5 +1,11 @@
-{ mkUserModule, ... }:
+# darwin runs the cask (its GUI owns the menu-bar state and the system
+# extension); linux runs the daemon from nixpkgs. Joining is still a
+# one-time manual `tailscale up` per host — no auth key lives in the repo.
+{ mkUserModule, forPlatform, ... }:
 mkUserModule {
   name = "tailscale";
   casks = [ "tailscale-app" ];
+  system = forPlatform {
+    linux.services.tailscale.enable = true;
+  };
 }

--- a/modules/system/sshd.nix
+++ b/modules/system/sshd.nix
@@ -1,26 +1,56 @@
-{ mkSystemModule, ... }:
+# SSH daemon hardening, expressed per platform because the two OSes take it
+# by different routes:
+#
+#   darwin — the daemon itself is toggled on demand by tmux-remote (Remote
+#     Login), so only the drop-in is declared. macOS sshd_config ends with an
+#     Include of sshd_config.d/*, which is what makes this file take effect.
+#
+#   linux — NixOS generates sshd_config wholesale from services.openssh and
+#     emits no sshd_config.d include, so the same rules have to be settings.
+#     The daemon IS declared here: polaris is reached over SSH by design.
+#
+# Kerberos/GSSAPI are omitted on linux rather than disabled: both already
+# default to no in OpenSSH, and naming a directive the local build lacks
+# fails sshd's config check at build time.
+{ mkSystemModule, forPlatform, ... }:
 mkSystemModule {
   name = "sshd";
-  config.environment.etc."ssh/sshd_config.d/200-hardening.conf" = {
-    text = ''
-      # Key-only authentication — no passwords, no keyboard-interactive
-      PubkeyAuthentication yes
-      PasswordAuthentication no
-      KbdInteractiveAuthentication no
-      PermitEmptyPasswords no
+  config = forPlatform {
+    darwin.environment.etc."ssh/sshd_config.d/200-hardening.conf" = {
+      text = ''
+        # Key-only authentication — no passwords, no keyboard-interactive
+        PubkeyAuthentication yes
+        PasswordAuthentication no
+        KbdInteractiveAuthentication no
+        PermitEmptyPasswords no
 
-      # No root login
-      PermitRootLogin no
+        # No root login
+        PermitRootLogin no
 
-      # Limit authentication attempts
-      MaxAuthTries 3
-      MaxSessions 5
-      LoginGraceTime 30
+        # Limit authentication attempts
+        MaxAuthTries 3
+        MaxSessions 5
+        LoginGraceTime 30
 
-      # Disable unused auth methods
-      HostbasedAuthentication no
-      KerberosAuthentication no
-      GSSAPIAuthentication no
-    '';
+        # Disable unused auth methods
+        HostbasedAuthentication no
+        KerberosAuthentication no
+        GSSAPIAuthentication no
+      '';
+    };
+
+    linux.services.openssh = {
+      enable = true;
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitEmptyPasswords = false;
+        PermitRootLogin = "no";
+        MaxAuthTries = 3;
+        MaxSessions = 5;
+        LoginGraceTime = 30;
+        HostbasedAuthentication = false;
+      };
+    };
   };
 }

--- a/modules/users/polaris-fernando.nix
+++ b/modules/users/polaris-fernando.nix
@@ -7,7 +7,14 @@ mkUser {
   # Shell & CLI
   atuin.enable = true;
   bat.enable = true;
-  ssh.enable = true;
+  ssh = {
+    enable = true;
+    # 1Password "SSH Key" — the auth key, distinct from the "SSH Signing Key"
+    # that modules/security/1password.nix hands to git.
+    authorizedKeys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBF9AdnNjLReo7Z2U0gifKkH3FR4str9pMvBbAcCzaj"
+    ];
+  };
   fish.enable = true;
   starship.enable = true;
   direnv.enable = true;
@@ -39,6 +46,9 @@ mkUser {
 
   # Chat
   discord.enable = true;
+
+  # Networking
+  tailscale.enable = true;
 
   # Security
   "1password".enable = true;


### PR DESCRIPTION
polaris had no remote access at all. The tailscale module was a darwin-only cask (`casks` is structurally absent on linux, so enabling it there was a no-op), and `services.openssh` was never set anywhere in the repo — the sshd hardening drop-in sat inert on a host running no daemon.

## Changes

- **tailscale** — linux branch enabling the nixpkgs daemon.
- **sshd** — NixOS generates `sshd_config` wholesale and emits no `sshd_config.d` include, so the darwin drop-in's rules are restated as `services.openssh.settings`. Kerberos/GSSAPI are omitted rather than disabled: both already default to `no`, and naming a directive the local build lacks fails sshd's config check at build time.
- **ssh** — `authorizedKeys` option, linux-guarded. Darwin's daemon is toggled ad hoc by `tmux-remote` and its keys come from the 1Password agent, so there's no declarative `authorized_keys` to own there.
- **server-mode** — new module. `sudo server-mode on|off`, plus unprivileged `server-mode status`.

## Why stopping the display manager

The idle cost worth cutting is the desktop session: niri plus the noctalia shell keep the 5070 Ti out of its deep idle states and hold the monitor awake. sshd and tailscale live in `multi-user.target`, so stopping `display-manager.service` never touches remote access. That name is greetd's own alias, so this keeps working if the greeter is swapped.

Deliberately **not** `systemctl isolate multi-user.target` — isolate is not guaranteed to spare the SSH session that issued it, and frees the same watts. `consoleblank=60` drops the monitor to DPMS off once the session is down; it only affects the VT, so desktop use is unchanged.

## Verification

- `nix flake check` — all checks passed
- polaris evaluates: `openssh.enable=true`, `tailscale.enable=true`, key in `authorizedKeys`, `consoleblank=60`, `server-mode` on PATH
- hardening lands as real settings: `PasswordAuthentication=false`, `PermitRootLogin="no"`, `MaxAuthTries=3`, `LoginGraceTime=30`
- vega unaffected: hardening drop-in still emitted, `tailscale-app` cask still present
- `statix` + `nixfmt` clean
- script logic exercised against a stubbed `systemctl` — all branches correct, bad arg exits 1

**Not verified:** no x86_64-linux builder here, so NixOS's build-time `sshd -t` validation and a real `display-manager` stop/start have not run. Both surface on the first `nixos-rebuild`.

## Follow-up

Joining the tailnet is still a manual `tailscale up` on polaris — no auth key lives in the repo.
