### PR TITLE
feat(ssh): add a polaris command that lands in polaris's tmux

### DIFF
--- a/modules/cli/ssh.nix
+++ b/modules/cli/ssh.nix
@@ -33,4 +33,29 @@ mkUserModule {
         }"
     '';
   };
+
+  # There is deliberately no `Host polaris` block: MagicDNS already resolves the
+  # node's tailnet name, so an ssh_config entry would only restate it. That also
+  # makes this self-healing — a node re-added to the tailnet keeps its name but
+  # not its address. (If MagicDNS is ever off, the node address is
+  # 100.123.15.108; hardcoding that is the fallback, not the default.)
+  #
+  # `polaris` lands straight in polaris's tmux, so the session survives the link
+  # dropping — the whole point of tmux on a box reached over the network.
+  # tmux-attach is the same entrypoint ghostty uses locally.
+  #
+  # It also opens a SOCKS5 proxy on 127.0.0.1:1080 that egresses from polaris.
+  # That is a convenience (a route out through the house), NOT the way this
+  # machine reaches the tailnet — reaching polaris is the precondition for the
+  # proxy, so it cannot also be the means. Point clients at it with
+  # `--socks5-hostname` (curl) or ProxyCommand (ssh) so names resolve on the
+  # polaris side. It is a full proxy, not a tailnet-only route: anything aimed
+  # at 1080 leaves via the house rather than via WARP.
+  home =
+    { userCfg, ... }:
+    {
+      programs.fish.shellAliases = lib.mkIf userCfg.fish.enable {
+        polaris = "ssh -D 1080 -t polaris tmux-attach";
+      };
+    };
 }

--- a/modules/cli/tmux/tmux.nix
+++ b/modules/cli/tmux/tmux.nix
@@ -311,6 +311,12 @@ mkUserModule {
           # Reload config with prefix + R
           bind-key R source-file ~/.config/tmux/tmux.conf \; display-message "Config reloaded"
 
+          # Reach a nested tmux: prefix twice. `polaris` attaches polaris's tmux
+          # from inside this one, and both ends run this same config, so without
+          # this every C-Space is eaten by the outer server and the inner one is
+          # uncontrollable.
+          bind-key C-Space send-prefix
+
           # New windows open at nearest git root; panes inherit current directory.
           # prefix+c reuses an idle window at that root if one exists (see
           # tmux-new-window); prefix+C always creates, mirroring the s/S split.


### PR DESCRIPTION
`polaris` opens a shell in polaris's existing tmux session over the tailnet, so the session survives the link dropping — the whole point of tmux on a box reached over the network. It reuses `tmux-attach`, the same entrypoint ghostty uses locally.

## Design notes

**No `Host polaris` in ssh_config.** MagicDNS already resolves the node's tailnet name, so an entry would only restate it. That also self-heals the case a hardcoded address cannot: a node re-added to a tailnet keeps its name but loses its address. If MagicDNS is ever disabled, the node address is in a comment as the fallback.

**The SOCKS5 proxy is a convenience, not the transport.** `-D 1080` gives a route out through the house, but reaching polaris is the precondition for the proxy, so it cannot also be the means of reaching it.

**`bind-key C-Space send-prefix`.** Both ends run this same tmux config, so without it the outer server eats every `C-Space` and the nested session is uncontrollable.

## Known limitation

Cloudflare WARP's Always-On profile drops egress bound to the physical NIC, and `tailscaled` binds there by design, so tailscale cannot connect on vega while WARP is up. Nothing in this repo can fix that — the WARP profile is org-managed. The workaround is `warp-cli disconnect` while using the tailnet.

## Verification

- `nixfmt --check`, `statix check .` clean
- `darwin-rebuild build --flake .#vega` exit 0
- `ssh -D` + `-t` + remote `tmux` verified composing end-to-end against polaris in a real terminal, and the SOCKS proxy verified reaching a tailnet address (`100.123.15.108`) with WARP connected
