### PR TITLE
fix(antiburn): stop every session fingerprint scanning the whole opencode db

### DIFF
--- a/modules/dev/antiburn/cluster-join-order.patch
+++ b/modules/dev/antiburn/cluster-join-order.patch
@@ -1,0 +1,41 @@
+diff --git a/crates/antiburn-local/src/discovery/agents/opencode.rs b/crates/antiburn-local/src/discovery/agents/opencode.rs
+index 420f2b9..b062afe 100644
+--- a/crates/antiburn-local/src/discovery/agents/opencode.rs
++++ b/crates/antiburn-local/src/discovery/agents/opencode.rs
+@@ -2781,14 +2781,33 @@ pub(crate) fn db_session_fingerprint_connection(
+     } else {
+         "WITH cluster(id) AS (SELECT id FROM session WHERE id = ?1)"
+     };
++    // `cluster` is a materialized CTE, so SQLite has no row-count estimate for
++    // it and picks the wrong loop order: it drives from `message` / `part` and
++    // probes `cluster` through an automatic covering index. That turns every
++    // fingerprint into a full scan of `part` — the largest table in the
++    // database — no matter how small the session is, so the cost is O(rows in
++    // the database) per session instead of O(rows in the session). Against a
++    // 7.7 GB `opencode.db` (5.4k sessions, 845k parts) that measured 1965 ms
++    // per session, and a scan fingerprints every session.
++    //
++    // `CROSS JOIN` keeps the join order exactly as written, which is SQLite's
++    // documented way to override the planner. Driving from `cluster` (one row
++    // for an unforked session) lets the inner lookup use `part_session_idx`
++    // and `message_session_time_created_id_idx` instead: 1.3 ms per session on
++    // the same database.
++    //
++    // The join order is a planner hint with no bearing on the result set:
++    // `CROSS JOIN` is an inner join in SQLite exactly as `JOIN` is, and
++    // `COUNT` / `MAX` are order-independent, so the fingerprint is identical
++    // under either plan.
+     conn.query_row(
+         &format!(
+             "{cluster}, records(updated) AS (
+-             SELECT COALESCE(time_updated, time_created, 0) FROM session JOIN cluster ON session.id = cluster.id
++             SELECT COALESCE(session.time_updated, session.time_created, 0) FROM cluster CROSS JOIN session ON session.id = cluster.id
+              UNION ALL
+-             SELECT COALESCE(time_updated, time_created, 0) FROM message JOIN cluster ON message.session_id = cluster.id
++             SELECT COALESCE(message.time_updated, message.time_created, 0) FROM cluster CROSS JOIN message ON message.session_id = cluster.id
+              UNION ALL
+-             SELECT COALESCE(time_updated, time_created, 0) FROM part JOIN cluster ON part.session_id = cluster.id
++             SELECT COALESCE(part.time_updated, part.time_created, 0) FROM cluster CROSS JOIN part ON part.session_id = cluster.id
+          )
+          SELECT COUNT(*), MAX(updated) FROM records"
+         ),

--- a/modules/dev/antiburn/package.nix
+++ b/modules/dev/antiburn/package.nix
@@ -59,18 +59,23 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "antiburn";
-  version = "0.3.3";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "antiburn";
     repo = "antiburn";
-    rev = "250b62733a6abeaa93ac6e76b0a0e958d2cf607b";
-    hash = "sha256-ZSroz7K9ReiWa/qbsSu2dGKXgSS1Xpeb+6A9leLhIew=";
+    rev = "fc5921447a8f030e525b2a95cf0568a3f25f99a4";
+    hash = "sha256-a63FNfD6X6b29TcUbB3qvquRW10v6mlmSaSYpn1STuQ=";
   };
 
   # Not passed to fetchPnpmDeps or cargoLock below: both read the unpatched
-  # src, and this patch only touches Rust, so neither hash moves.
-  patches = [ ./sqlite-connection-reuse.patch ];
+  # src, and these patches only touch Rust, so neither hash moves. Order
+  # matters — cluster-join-order.patch is cut against the tree
+  # sqlite-connection-reuse.patch leaves behind.
+  patches = [
+    ./sqlite-connection-reuse.patch
+    ./cluster-join-order.patch
+  ];
 
   # Only the desktop app is needed to produce the frontend bundle. The
   # workspace root's devDependencies are lint/CI tooling (secretlint, and an
@@ -97,7 +102,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         ;
       pnpm = pnpm_11;
       fetcherVersion = 3;
-      hash = "sha256-yfN8xdqSGmd5HUPLdocuW7L/GTjhJx4g8BhajYtdOlY=";
+      hash = "sha256-OuZZ0S0nxH1UIr9lIJbBTSJXEaBGVr/+n6tyXGsmcpk=";
     }).overrideAttrs
       (old: {
         installPhase =
@@ -107,7 +112,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     # Updater artifacts need upstream's minisign key, which we do not have.
-    jq '.bundle.createUpdaterArtifacts = false' apps/desktop/src-tauri/tauri.conf.json \
+    #
+    # Blanking the public key is the other half of that same decision, and it
+    # is upstream's own off-switch: `install_updater` returns early on an empty
+    # `plugins.updater.pubkey`, so the plugin is never registered and no check
+    # ever reaches the network. Nix owns this install — the app lives in the
+    # read-only store, where a self-update can only fail (observed: "Cross-device
+    # link (os error 18)" after downloading the whole payload). Leaving the key
+    # in place buys a download every six hours and an update nudge for an
+    # install that cannot happen; `darwin-rebuild` is the upgrade path.
+    jq '.bundle.createUpdaterArtifacts = false | .plugins.updater.pubkey = ""' \
+      apps/desktop/src-tauri/tauri.conf.json \
       | sponge apps/desktop/src-tauri/tauri.conf.json
 
     # The repo pins rust 1.97; nixpkgs is on 1.94. The pin is a floor, not a


### PR DESCRIPTION
antiburn was sitting at **983% CPU** (~10 cores), sustained. All of it was one
function.

## The CPU bug

`db_session_fingerprint_connection` builds `cluster` as a materialized CTE, so
SQLite has no row-count estimate for it and picks the wrong loop order:

```
|--UNION ALL
|  |--SCAN part                                 <-- full scan, 845k rows / 7.7 GB
|  `--SEARCH cluster USING AUTOMATIC COVERING INDEX (id=?)
```

It drives from the big table and probes `cluster`, instead of driving from the
one-row `cluster` and using `part_session_idx`. So every fingerprint full-scans
`part` regardless of session size, and a scan fingerprints every session.

`CROSS JOIN` keeps the join order as written, which is SQLite's documented way
to override the planner:

| | before | after |
|---|---|---|
| per fingerprint | 1965 ms | 1.3 ms |
| process CPU | 983% | 0.1% |
| profile samples in that query | 84,822 | 0 |

Planning-only change: `CROSS JOIN` is an inner join like `JOIN`, and
`COUNT`/`MAX` are order-independent. Output verified identical across 60
sessions (20 forked, 20 largest, 20 random), plus the non-recursive `cluster`
branch and the missing-session case on a synthetic db.

## The auto-updater

It cannot work here — the app lives in the read-only nix store:

```
auto_update_found        version=0.4.0
updater_download_started version=0.4.0 automatic=true
updater_install_failed   error=Cross-device link (os error 18)
```

A full download every six hours plus an update nudge, for an install that always
fails. Blanking `plugins.updater.pubkey` is upstream's own off-switch:
`install_updater` returns early on an empty key, so the plugin is never
registered and nothing reaches the network. It is also the other half of the
`createUpdaterArtifacts = false` decision already in this file.

## 0.4.0

`opencode.rs` is **byte-identical** between 0.3.3 and 0.4.0, so neither bug is
fixed upstream and both patches apply unchanged. Only the pnpmDeps hash needed
refreshing — the pnpm pin is still `11.6.0`, and `tauri-nspanel` / `tray-icon`
are at the same git revs, so `cargoLock.outputHashes` is untouched.

## Verified on the built 0.4.0 binary

- `app_started version="0.4.0"`
- CROSS JOIN present, old `part JOIN cluster` absent
- minisign pubkey blank; `updater_disabled_no_public_key`, no check fired at 75s
- 22 open handles on `opencode.db`, so it is genuinely scanning
- 0.1% CPU over 60s
