### PR TITLE
chore: update the flake, and drop three workarounds it made redundant

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779378574,
-        "narHash": "sha256-1NGjx2DBvqPYMMwFnth0dHeCJiHG+LG7EWefB1WmJls=",
+        "lastModified": 1788591592,
+        "narHash": "sha256-NbwVKwKLFl0oXub7oPjvmDaOygCtV2oboeKTu4xXFTk=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "d8deaca5574faf79a27f110caedc9e153709e628",
+        "rev": "08e85c4e42f5d8f1ea17c36cb59cf61c2ccb26c3",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.13",
+        "ref": "6.0.22",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1786845137,
+        "narHash": "sha256-oQFip+v0luP8NIxJzmiW4Wu8bILsbFWom5l0zonl8hQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "4cff07de74b50e64bdd68cd4e722ab5b6b35ee48",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1776064408,
-        "narHash": "sha256-usJh+oOUfRDHvWd1rRjSJX/OyRskHqumg93laPhz88I=",
+        "lastModified": 1788419217,
+        "narHash": "sha256-2GwP6Sot2NNBh7nUOi0y08m1RGwknIro+jMIM1yawz8=",
         "owner": "Mic92",
         "repo": "direnv-instant",
-        "rev": "f1a33bf99b030e3289b9eb00fdfea81437eda536",
+        "rev": "d5cb5b1e1edc7ec17344839b1ce1d791d3785a7c",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
     "hermes-claude-auth": {
       "flake": false,
       "locked": {
-        "lastModified": 1778085628,
-        "narHash": "sha256-8WYUtBZacHsUToz78r2KTPzkV5m7uPguI6VVOoAFhBE=",
+        "lastModified": 1787048326,
+        "narHash": "sha256-eq8cMgQh3fXthvTE7M30kG9rW2gNiZJ0skB9SOyLIWA=",
         "owner": "kristianvast",
         "repo": "hermes-claude-auth",
-        "rev": "b7999195bd538870c6876930c16357094f91af10",
+        "rev": "6525928e13a2771ca0fcf0539ea286150e83c421",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779580960,
-        "narHash": "sha256-/EG2rRahtxdoKKzGPGqaymVB96kBBYhygatEAbsoqaM=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e92bf094d45bc33d754e2b0f75d9ca1827cc363",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783963347,
-        "narHash": "sha256-r376E2XpakiXwModDHIxlvB6qLq4iFVEq730vxOO4JY=",
+        "lastModified": 1788651960,
+        "narHash": "sha256-v9wJd32eZ2bvhBzVOd7TIjLQd011P7nwOhjKtWlci5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a45a7c451455a51ae740ec3bce4024b312809c29",
+        "rev": "2c0350c759688177331b8f5242311fae8877bdb3",
         "type": "github"
       },
       "original": {
@@ -242,11 +242,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1781046746,
-        "narHash": "sha256-bjTwrQoTJ3Od8+o1RQywFDuVIzPvnxD8tWCUZ4B7+O0=",
+        "lastModified": 1788897407,
+        "narHash": "sha256-UWqhDbFvNJN8PlhUHuGU9NGR8fMZ2eB5/0zojdMeK4s=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "db01eda215aa2d3022e0fc18ea632baa2a3ba87e",
+        "rev": "f9fe26683def95a1ae40130a856dc97441b51aad",
         "type": "github"
       },
       "original": {
@@ -258,11 +258,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1779582969,
-        "narHash": "sha256-hvyHNy2JFXLUHCIDve2zhQOqrIYTyTnxc62uvJe7Ov4=",
+        "lastModified": 1788895556,
+        "narHash": "sha256-OZNQV53jjcFo0QxBtPJ/aE5DrkseIlcVUpTe6M/KdCM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "0cbd19f57c213d4b7f9bc74c64410143ecb7a29e",
+        "rev": "77f4bb7e8aa136e72360b5ad90c2b51968689d4e",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
     "homebrew-schpet-tap": {
       "flake": false,
       "locked": {
-        "lastModified": 1776285540,
-        "narHash": "sha256-0cIEJiOlfOyRU/w3TOGiyMeluoaVexzEJd7Og2DELeQ=",
+        "lastModified": 1788377367,
+        "narHash": "sha256-fAyCw79ZyXI526jmweybE6b908+SoF1vJCwZrxK4Uhg=",
         "owner": "schpet",
         "repo": "homebrew-tap",
-        "rev": "c256873d145d6a012165b89c28a1e8ce5256bec7",
+        "rev": "638d0ca08b0308bf93983aef404eab09c7e05a05",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1788444135,
+        "narHash": "sha256-ChwTDZPvTmEgZdS30dUfgdXlzAPtZAUWwEH/PfDXZmg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "ec8417a617de4d3c739aed40837e308ebd667165",
         "type": "github"
       },
       "original": {
@@ -316,11 +316,11 @@
         "qmd": "qmd"
       },
       "locked": {
-        "lastModified": 1786643324,
-        "narHash": "sha256-ighXL0KhBd1k/ia8+5xvvrsOuMI6VcfvSeaUaCuyPos=",
+        "lastModified": 1788831752,
+        "narHash": "sha256-sL7ZYBKRhfeCw8dtkoo+JT+mCHfhw6cnSAuAVA5fvVI=",
         "owner": "openclaw",
         "repo": "nix-openclaw",
-        "rev": "4a27671497057be5bf91cc38cdaebb3280b77220",
+        "rev": "5cbb2f1bdaf89575076cf95e9cee59c851c967fe",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1778060041,
-        "narHash": "sha256-tXWkN1VnwFG8XlRqW/e7VwbKnUfyU9tB7YDm9QHJXTY=",
+        "lastModified": 1788766984,
+        "narHash": "sha256-FF75z2jVZJjymkLtt7e7rKBLQZtC1LBEoM8qDhQPLQ8=",
         "owner": "openclaw",
         "repo": "nix-openclaw-tools",
-        "rev": "4c1cee3c7eaf68f9de0f756be1484534f5bb5f34",
+        "rev": "25fcec492e22996af9ee87106338a448bc6893a2",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781324273,
-        "narHash": "sha256-8o3W8DlntG3V49csNA/po1r0OAuyAuGtAclzl9rKOeM=",
+        "lastModified": 1788840199,
+        "narHash": "sha256-bNgtpZtQ/NkL5lKdfvY2jr2ueUNtiNhq/U1MctWZQO0=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "75312cf67b194550cac918d13bdaafc5b56b6795",
+        "rev": "41316674b7aaf38b1f9b2415ba153db82ea092cf",
         "type": "github"
       },
       "original": {
@@ -385,11 +385,11 @@
     },
     "nixpkgs-nixos": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {
@@ -401,11 +401,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1788752844,
+        "narHash": "sha256-VaWGJ6+cIYN2erfSecbRV+4ljI185Ty2wUrXyvQbgOw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "dc5d91f840324650bac8c379428c7037a416959a",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1788865024,
+        "narHash": "sha256-3YkAzvtt4LoE11IcBDzPshIF3fJ0aIoILqE7dAg8CLI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "422d1ae605d7fcd9896412b37dc065c456c0eefb",
         "type": "github"
       },
       "original": {
@@ -453,11 +453,11 @@
         "noctalia-qs": "noctalia-qs"
       },
       "locked": {
-        "lastModified": 1783017890,
-        "narHash": "sha256-bAzrtN0GDMH0dOZkgeI3zSxfFs2rdD3pMuzOxvTF0bs=",
+        "lastModified": 1788016978,
+        "narHash": "sha256-kq3bbBPa5803bLv55bNFztx2YryJl5a/VfUWvvdaZjI=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "a48885b9fec485c903c955749a7da6e30147cd38",
+        "rev": "a08ff3619ed4c1e1cd8b7691438cea34ccecd6c5",
         "type": "github"
       },
       "original": {
@@ -632,16 +632,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1775429264,
-        "narHash": "sha256-bqIVaNRTa8H5vrw3RwsD7QdtTa0xNvRuEVzlzE1hIBQ=",
+        "lastModified": 1786919312,
+        "narHash": "sha256-/7Z94r/9rXqzKlz/YkB6/nToSCPamV4Dnxm8EhelTDo=",
         "owner": "tobi",
         "repo": "qmd",
-        "rev": "65cd1b3fd02891d1ee0eefa751620918664fa321",
+        "rev": "facd35e01359e59d938bc9418e93fb9318addee3",
         "type": "github"
       },
       "original": {
         "owner": "tobi",
-        "ref": "v2.1.0",
+        "ref": "v2.8.3",
         "repo": "qmd",
         "type": "github"
       }
@@ -722,11 +722,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,12 +34,17 @@
       inputs.brew-src.follows = "brew-src";
     };
 
-    # Pin brew to a version that includes the cask OS-dependency regression fix
-    # (https://github.com/Homebrew/brew/pull/22261), required for casks like
-    # stremio and iina that combine `on_arm`/`on_intel` macOS deps with a
-    # top-level `depends_on :macos`.
+    # Floor is brew 6.0.0: nix-darwin's homebrew activation passes
+    # `--zap --force-cleanup` to `brew bundle`, and `--force-cleanup` did not
+    # exist before 6.0.0 (5.x only had `-f`/`--force`), so an older brew aborts
+    # activation with "Error: invalid option: --force-cleanup".
+    #
+    # Also still satisfies the reason this was pinned in the first place: the
+    # cask OS-dependency regression fix (https://github.com/Homebrew/brew/pull/22261),
+    # required for casks like stremio and iina that combine `on_arm`/`on_intel`
+    # macOS deps with a top-level `depends_on :macos`.
     brew-src = {
-      url = "github:Homebrew/brew/5.1.13";
+      url = "github:Homebrew/brew/6.0.22";
       flake = false;
     };
 

--- a/modules/cli/worktree/stacked.nix
+++ b/modules/cli/worktree/stacked.nix
@@ -22,25 +22,6 @@
 let
   inherit (pkgs) lib;
 
-  # nixpkgs ships git-revise 0.7.0 (GPG-only signing). git-stack-cli rebases via
-  # `git revise`, and commits here are signed with SSH (1Password) — unsupported
-  # until v0.8.0 (PR #136). Without it the revise step aborts trying to run a
-  # missing `gpg`. Override to 0.8.0 so it signs via gpg.format=ssh +
-  # gpg.ssh.program (op-ssh-sign), keeping the stack's commits signed.
-  git-revise = pkgs.git-revise.overridePythonAttrs (old: {
-    version = "0.8.0";
-    src = pkgs.fetchurl {
-      url = "https://files.pythonhosted.org/packages/source/g/git-revise/git_revise-0.8.0.tar.gz";
-      hash = "sha256-MjmxgJzWWbM/bzI9O/ylx+Op6y6s4iPPY7NG+RyMgxw=";
-    };
-    # 0.8.0 switched setup.py → pyproject.toml (hatchling), and its PyPI sdist
-    # omits the tests dir, so the upstream pytest checkPhase collects nothing
-    # and fails — build it as a pyproject and skip the check.
-    format = "pyproject";
-    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.python3.pkgs.hatchling ];
-    doCheck = false;
-  });
-
   git-stack-cli = pkgs.stdenvNoCC.mkDerivation {
     pname = "git-stack-cli";
     version = "2.11.0";
@@ -103,10 +84,12 @@ in
 {
   home = {
     # git-stack is the engine; git-revise is the in-memory rebase helper it
-    # shells out to. gh comes from the git module.
+    # shells out to. gh comes from the git module. git-revise must stay >= 0.8.0
+    # (PR #136): commits here are SSH-signed via 1Password, and 0.7.0 was
+    # GPG-only, so the revise step aborted looking for a missing `gpg`.
     home.packages = [
       git-stack-cli
-      git-revise
+      pkgs.git-revise
     ];
 
     programs.fish = {
@@ -211,7 +194,7 @@ in
         # which the binary honors globally across every subcommand (several reject
         # the -b flag, e.g. rebase). git-stack-cli only auto-detects
         # origin/master|main, so this is what makes it work on any default branch
-        # (e.g. prod). Signing is left ON — `git revise` (0.8.0 override above)
+        # (e.g. prod). Signing is left ON — `git revise` (>= 0.8.0)
         # SSH-signs via 1Password. Scoped to the call via `env`; an explicit
         # GIT_STACK_CONFIG override is respected.
         _wts_gs = ''

--- a/modules/dev/antiburn/package.nix
+++ b/modules/dev/antiburn/package.nix
@@ -17,46 +17,12 @@
   runCommand,
   jq,
   moreutils,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
   cargo-tauri,
 }:
-let
-  # nixpkgs has no pnpm_11, and the repo's pnpm-workspace.yaml uses pnpm 11
-  # syntax that pnpm 10 rejects (`allowBuilds` keyed by a URL spec ->
-  # ERR_PNPM_INVALID_VERSION_UNION). pnpm is just an npm tarball, so a
-  # version+hash override is enough.
-  #
-  # The relink is required: pnpm 11 moved the real entry point to pnpm.mjs
-  # and left pnpm.cjs as a non-executable shim, but generic.nix still
-  # symlinks bin/pnpm -> pnpm.cjs, which fails with "Permission denied".
-  pnpm_11 =
-    (pnpm_10.override {
-      version = "11.6.0";
-      hash = "sha256-oBYpSdGrGeEuizzZ8PWe8C1750oouAbPf0n7f0wH5c4=";
-    }).overrideAttrs
-      (old: {
-        postInstall = (old.postInstall or "") + ''
-          ln -sf $out/libexec/pnpm/bin/pnpm.mjs $out/bin/pnpm
-          ln -sf $out/libexec/pnpm/bin/pnpx.mjs $out/bin/pnpx
-        '';
-      });
-
-  # pnpmConfigHook carries its own copy of the same unsupported `pnpm config
-  # set manage-package-manager-versions false` call as the fetcher, and runs
-  # it at build time. Same reasoning, same fix — but makeSetupHook builds
-  # with a fixed buildCommand and never runs postInstall, so the hook has to
-  # be copied and patched rather than overridden. Copying the whole output
-  # preserves nix-support/propagated-build-inputs, so propagation survives.
-  pnpmConfigHook' = runCommand "pnpm-config-hook-pnpm11" { } ''
-    cp -r ${pnpmConfigHook} $out
-    chmod -R u+w $out
-    substituteInPlace $out/nix-support/setup-hook \
-      --replace-fail 'pnpm config set manage-package-manager-versions false' true
-  '';
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "antiburn";
   version = "0.4.0";
@@ -84,31 +50,19 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # deps, which the fetcher does not materialize.
   pnpmWorkspaces = [ "@antiburn/desktop" ];
 
-  # nixpkgs' fetcher hardcodes `pnpm config set
-  # manage-package-manager-versions false` into its installPhase, ahead of
-  # any hook we could use. pnpm 11 dropped that key from the global config
-  # and errors out (ERR_PNPM_CONFIG_SET_UNSUPPORTED_YAML_CONFIG_KEY). The
-  # setting exists to stop pnpm self-managing a version mismatch against
-  # package.json's `packageManager` field — ours is exactly the pinned
-  # 11.6.0, so there is no mismatch to manage and dropping the call is a
-  # no-op for us.
-  pnpmDeps =
-    (fetchPnpmDeps {
-      inherit (finalAttrs)
-        pname
-        version
-        src
-        pnpmWorkspaces
-        ;
-      pnpm = pnpm_11;
-      fetcherVersion = 3;
-      hash = "sha256-OuZZ0S0nxH1UIr9lIJbBTSJXEaBGVr/+n6tyXGsmcpk=";
-    }).overrideAttrs
-      (old: {
-        installPhase =
-          builtins.replaceStrings [ "pnpm config set manage-package-manager-versions false" ] [ "true" ]
-            old.installPhase;
-      });
+  # fetcherVersion 4 (SQL dump of the store db) is mandatory on pnpm 11 —
+  # the fetcher rejects 3 outright.
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-OuZZ0S0nxH1UIr9lIJbBTSJXEaBGVr/+n6tyXGsmcpk=";
+  };
 
   postPatch = ''
     # Updater artifacts need upstream's minisign key, which we do not have.
@@ -131,15 +85,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # as antiburn-trace carry their own pin and cargo fails on the first one.
     find . -name Cargo.toml -exec sed -i '/^rust-version = /d' {} +
   '';
-
-  # pnpm 11 re-applies minimumReleaseAge/trustPolicy to every lockfile entry
-  # on install, and that verification talks to the registry — which the build
-  # sandbox has no network for, so it blocks forever (observed: pnpm asleep at
-  # 0% CPU with zero connections). The lockfile here is trusted base: it comes
-  # from a content-hashed source derivation and the packages themselves are
-  # already pinned by the pnpmDeps hash, so re-verifying publish dates adds
-  # nothing this build can act on.
-  pnpmInstallFlags = [ "--trust-lockfile" ];
 
   cargoRoot = "apps/desktop/src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
@@ -165,7 +110,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     jq
     moreutils
-    pnpmConfigHook'
+    pnpmConfigHook
     pnpm_11
     nodejs
     cargo-tauri.hook

--- a/modules/dev/opencode/agentation-mcp.nix
+++ b/modules/dev/opencode/agentation-mcp.nix
@@ -13,7 +13,7 @@ let
   # See figma-developer-mcp.nix for context: Node.js 24.15.0 in current
   # nixpkgs crashes pnpm with "Abort trap: 6". Pin the pnpm runtime to
   # nodejs_22 (LTS) which doesn't have the FD-tracking regression.
-  pnpm = pnpm_10.override { nodejs = nodejs_22; };
+  pnpm = pnpm_10.override { nodejs-slim = nodejs_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "agentation-mcp";

--- a/modules/dev/opencode/figma-developer-mcp.nix
+++ b/modules/dev/opencode/figma-developer-mcp.nix
@@ -18,7 +18,7 @@ let
   # FD-tracking regression. The fetchPnpmDeps `pnpm` arg controls only the
   # pnpm binary used to populate the offline store — runtime use of the
   # output by downstream builds is unaffected.
-  pnpm = pnpm_10.override { nodejs = nodejs_22; };
+  pnpm = pnpm_10.override { nodejs-slim = nodejs_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "figma-developer-mcp";

--- a/modules/editor/vscode/vscode.nix
+++ b/modules/editor/vscode/vscode.nix
@@ -34,16 +34,18 @@ let
     in
     if attempt.success then attempt.value else null;
 
-  # Extensions whose marketplace package fails to *build* on this platform —
-  # tryEval below only catches eval-time failures. They keep working as
-  # manual installs via mutableExtensionsDir.
+  # Extensions whose marketplace package fails to *build* — tryEval below only
+  # catches eval-time failures. They keep working as manual installs via
+  # mutableExtensionsDir.
   # ponytail: hardcoded skip list; generalize only if it grows.
-  brokenOnThisPlatform = forPlatform {
-    # oxc resolves to an ancient 0.0.2 vsix on linux whose package.json
-    # trips the extension builder ("cannot use null as iterable").
-    linux = [ "oxc.oxc-vscode" ];
-  };
-  declaredIds = lib.subtractLists brokenOnThisPlatform (import ./extensions.nix);
+  brokenExtensions = [
+    # Abandoned under this id: the marketplace only carries an 0.0.2 vsix from
+    # 2023, whose package.json trips the extension builder ("cannot use null as
+    # iterable"). Was linux-only until the 26.11 builder rejected it on darwin
+    # too — no newer version exists to move to.
+    "oxc.oxc-vscode"
+  ];
+  declaredIds = lib.subtractLists brokenExtensions (import ./extensions.nix);
   resolvedExtensions = builtins.filter (pkg: pkg != null) (map resolve declaredIds);
   unavailableIds = builtins.filter (id: resolve id == null) declaredIds;
   extensions =
@@ -86,7 +88,7 @@ let
       echo "]"
     } > "$tmp"
 
-    ${pkgs.nixfmt-rfc-style}/bin/nixfmt "$tmp" >/dev/null 2>&1 || true
+    ${pkgs.nixfmt}/bin/nixfmt "$tmp" >/dev/null 2>&1 || true
     mv "$tmp" "$out"
 
     echo "vscode-sync-extensions: wrote $out"


### PR DESCRIPTION
nixpkgs was five months behind (2026-04-16). This moves it, home-manager and nix-darwin to current, and takes the fallout in the same commit — the module fixes only exist against the new nixpkgs, so no split leaves a tree that builds.

Net **−65 lines**: most of the diff is deletion, because nixpkgs absorbed workarounds this repo was carrying by hand.

## Inputs

| Input | Was | Now |
|---|---|---|
| nixpkgs | 2026-04-16 | 2026-09-08 |
| home-manager | 2026-05-24 | 2026-09-05 |
| nix-darwin | 2026-04-01 | 2026-08-16 |
| nix-vscode-extensions | 2026-06-13 | 2026-09-08 |
| homebrew-cask / core | 2026-06-09 / 05-24 | 2026-09-08 |
| brew-src | 5.1.13 | 6.0.22 |
| nix-openclaw, noctalia, nix-homebrew, disko, direnv-instant, hermes-claude-auth | Apr–Aug | Aug–Sep |

Version-tagged pins left alone (immutable): `opencode v1.18.29`, `hermes-agent v2026.5.29.2`.

## Workarounds retired

**git-revise** — nixpkgs now ships 0.8.0, exactly the version the override existed to force. The new `mk-python-derivation` also asserts `pyproject` and `format` are mutually exclusive, which is what surfaced it. Override deleted; the `>= 0.8.0` requirement (SSH signing, [PR #136](https://github.com/mystor/git-revise/pull/136)) survives as a comment.

**antiburn** — nixpkgs has `pnpm_11` (11.25.0) and handles it natively, exporting `pnpm_config_pm_on_fail` and `pnpm_config_trust_lockfile` instead of the `pnpm config set manage-package-manager-versions false` call that pnpm 11 rejects. Retires the hand-rolled `pnpm_11`, the copied-and-patched `pnpmConfigHook`, the `pnpmDeps` installPhase rewrite and `pnpmInstallFlags`. `fetcherVersion` 3 → 4, now required on pnpm 11.

**oxc.oxc-vscode** — abandoned under that id: the marketplace only carries an 0.0.2 vsix from 2023, and the 26.11 extension builder now rejects it on darwin too, not just linux. Reuses the existing skip list, made unconditional. Still installable by hand through `mutableExtensionsDir`.

## Homebrew

brew 5.1.13 → 6.0.22. nix-darwin's activation now passes `--zap --force-cleanup` to `brew bundle`, and `--force-cleanup` did not exist before brew 6.0.0 — 5.x only had `-f`/`--force`, so activation aborted with `Error: invalid option: --force-cleanup` before touching a single cask.

6.0.22 still carries the cask OS-dependency fix ([brew#22261](https://github.com/Homebrew/brew/pull/22261)) the pin was created for, so the pin is now a floor rather than a hold.

## Deprecations

`nixfmt-rfc-style` → plain `nixfmt`, and pnpm wants `nodejs-slim` overridden rather than `nodejs`. The `nodejs_22` pin itself stays — it still works around the Node 24.15.0 "Abort trap: 6" crash, not the deprecated argument name. Eval warnings now 0.

## Verification

- `darwin-rebuild build --flake .#vega` — exit 0
- `nix flake check` — green (nvim, hammerspoon and todoist Lua byte-compiled)
- `statix check .` — clean, `nixfmt` applied
- Closure contains `claude-code-2.1.263` and `git-revise-0.8.0`
- New brew accepts `--no-upgrade`, `--zap`, `--force-cleanup` (exit 0)
- `darwin-rebuild switch` confirmed working on vega
