### PR TITLE
feat(codegraph): run codegraph from nixpkgs, not oh-my-openagent's pin

### DIFF
--- a/modules/dev/opencode/codegraph.nix
+++ b/modules/dev/opencode/codegraph.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+{
+  home = {
+    # OMO_CODEGRAPH_BIN is the FIRST branch of oh-my-openagent's
+    # resolveCodegraphCommand, and resolveOrProvisionCommand returns early on
+    # `resolved.exists`. Setting it therefore skips two things that are
+    # otherwise broken here:
+    #
+    #   1. The version pin. OMO provisions CODEGRAPH_PINNED_VERSION = 1.5.0,
+    #      whose catch-up sync dies on "Maximum call stack size exceeded" and
+    #      leaves the daemon spinning. There is no config knob for the version;
+    #      the binary override is the only way past it.
+    #   2. The Node gate. OMO checks `which node` against a supported range of
+    #      20..24 BEFORE provisioning, and rejects this machine's Node 26 as
+    #      unsupported — even though codegraph's own shim execs a bundled Node
+    #      and never touches the system one. The early return means that check
+    #      never runs, so no Node needs to be installed at all.
+    home.sessionVariables.OMO_CODEGRAPH_BIN = "${pkgs.codegraph}/bin/codegraph";
+  };
+}

--- a/modules/dev/opencode/opencode.nix
+++ b/modules/dev/opencode/opencode.nix
@@ -41,6 +41,7 @@ mkUserModule {
     cache = import ./cache.nix { };
     omo-gitignore = import ./omo-gitignore.nix { };
     omo = import ./omo.nix { inherit pkgs; };
+    codegraph = import ./codegraph.nix { inherit pkgs; };
     worktree-move = import ./worktree-move.nix { };
     session-search = import ./session-search.nix { inherit pkgs; };
   };


### PR DESCRIPTION
Points oh-my-openagent at a Nix-built codegraph instead of the copy it downloads into `~/.omo/codegraph`.

## Why

Two separate things were broken with OMO's own copy.

**The daemon spins forever.** OMO hard-pins `CODEGRAPH_PINNED_VERSION = "1.5.0"`. That version's catch-up sync dies with `Maximum call stack size exceeded`, and the error is swallowed by a bare `.catch()` that only logs, so the daemon never settles:

```
[CodeGraph MCP] Catch-up sync failed: Maximum call stack size exceeded
```

Two of them were found at **560% and 475% CPU after 17 hours**, on a load average of 23. Exactly the projects carrying that log line were the runaway ones. There is no config knob for the version — the OMO schema exposes `enabled`, `daemon`, `auto_init`, `auto_provision`, `excluded_roots`, `install_dir`, `telemetry`, `watch_debounce_ms`, and nothing else.

**Codegraph wasn't starting at all.** OMO gates the bootstrap on `which node` against a supported range of 20..24. This machine has Node 26, so `opencode mcp list` showed `codegraph — disabled`. It logs misleadingly:

```
CodeGraph unsupported on this Node runtime; skipping bootstrap {"major":0,"reason":"too-old"}
```

`major: 0` because the runtime resolver returns `null` and the version falls back to `"0.0.0"`. The gate is spurious for a provisioned install anyway — codegraph's shim is `exec "$DIR/node" ... codegraph.js`, so it runs a bundled Node and never touches the system one.

## How

`OMO_CODEGRAPH_BIN` is the first branch of `resolveCodegraphCommand`, and `resolveOrProvisionCommand` returns early on it:

```js
const resolved = resolveInitialCommand(deps, config3);
if (resolved.exists) return resolved;      // ← external binary exits here
if (config3.auto_provision === false) return null;
const nodeSupport = deps.nodeSupport();    // ← never reached
```

So one env var skips both the version pin and the Node check. No Node needs to be installed, and the mutable `~/.omo` download becomes a store path.

`pkgs.codegraph` is already 1.6.0 on the current `nixpkgs` pin — no new input, no lock churn.

## Verification

Confirmed live after switching, reading the running process's own environment:

```
pid 11707  /nix/store/vlj6p7w9...-codegraph-1.6.0/lib/codegraph/node ...
  OMO_CODEGRAPH_BIN=/nix/store/vlj6p7w9...-codegraph-1.6.0/bin/codegraph
  CODEGRAPH_NO_DAEMON=1
●  ✓ codegraph connected
```

No `~/.omo/codegraph` anywhere in that path. Load average went 23.12 → ~3.5 with zero daemons running.

## Note

`codegraph.daemon = false` still lives in `~/.omo/omo.jsonc`, outside Nix. It stays as belt-and-braces because whether 1.6.0 fixes the underlying stack-overflow is unverified. Making that declarative is a separate change — it needs Nix to own `omo.jsonc`, since the `oh-my-openagent.json` this repo generates is no longer read by OMO after its config-unification migration.
