### PR TITLE
feat(anydesk): add the AnyDesk cask

### DIFF
--- a/modules/productivity/anydesk.nix
+++ b/modules/productivity/anydesk.nix
@@ -1,0 +1,5 @@
+{ mkUserModule, ... }:
+mkUserModule {
+  name = "anydesk";
+  casks = [ "anydesk" ];
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -147,6 +147,7 @@ mkUser {
   libreoffice.enable = true;
   word.enable = true;
   "windows-app".enable = true;
+  anydesk.enable = true;
   granola.enable = true;
   "wispr-flow".enable = true;
   "cold-turkey-blocker".enable = false;


### PR DESCRIPTION
Adds AnyDesk as a Homebrew cask module, enabled for `fernando` on `vega`.

## Why

Remote desktop access to machines that neither SSH nor Screen Sharing reach.

Nothing special about the module — it is the same four-line cask shape as every other GUI-only app in `modules/productivity/`, so it needs no system config and no outbound integrations.

## Verification

```
nix eval --json .#darwinConfigurations.vega.config.homebrew.casks | grep anydesk
```

Evaluates clean and `"anydesk"` lands in the cask list. `statix check .` and `nixfmt --check` both pass.