### PR TITLE
feat(slack): add Later statusbar count and task pane

### DIFF
--- a/modules/chat/slack.nix
+++ b/modules/chat/slack.nix
@@ -1,5 +1,0 @@
-{ mkUserModule, ... }:
-mkUserModule {
-  name = "slack";
-  casks = [ "slack" ];
-}

--- a/modules/chat/slack/README.md
+++ b/modules/chat/slack/README.md
@@ -1,0 +1,44 @@
+# Slack Later in tmux
+
+This opt-in integration uses an isolated Chrome profile, not desktop Slack or
+the normal Chrome "Telepatia" profile. It reads undocumented Slack endpoints;
+session expiry and workspace security policies still apply.
+
+## Sign in or renew the session
+
+Run this in your shell, then complete Slack sign-in in the new browser window:
+
+```fish
+open -na "Google Chrome" --args \
+  --user-data-dir="$HOME/.local/share/tmux-slack-later/chrome" \
+  --profile-directory=Default --no-first-run --no-default-browser-check \
+  https://telepatiaworkspace.slack.com/
+```
+
+Choose to use Slack in the browser. Do not import another profile or enable
+Chrome Sync. Signing in here is separate from signing into desktop Slack.
+Chrome Safe Storage in the macOS login Keychain decrypts this profile's cookies;
+approve access if prompted. Never paste credentials into Nix configuration.
+
+## Use
+
+Enable `slack.later.enable` and set `slack.later.workspace` to the exact workspace
+domain. The statusbar refreshes every 15 minutes. `prefix + L` opens a right-hand
+pane: Enter opens a message, `/` searches, `r` refreshes, and `q` closes it.
+Esc leaves search first, then closes the pane from menu mode.
+
+The pane displays cached rows immediately while fetching updated data. A `!`
+in the statusbar or an error in the pane means the last successful data may be
+stale. Sign in again using the same command above, then press `r` in the pane.
+
+Slack accepts fewer than 50 items per page. This viewer shows up to 49, with an
+explicit truncation label when more exist. It never completes, deletes, or sends
+anything. Cached snippets are private files under `~/.cache/tmux-slack-later`;
+decrypted cookies live only in a private temporary directory during refresh.
+
+## Offline checks
+
+```fish
+bash modules/chat/slack/later.test.sh
+bash modules/chat/slack/later-pane.test.sh
+```

--- a/modules/chat/slack/later-pane.sh
+++ b/modules/chat/slack/later-pane.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Read-only Slack Later list for a real tmux pane (prefix+L splits 40% right).
+# Strictly a viewer: it reads the backend's `tmux-slack-later-list` JSON and
+# opens a row. Nothing here completes, snoozes or mutates a saved item, so the
+# pane cannot damage the list it shows. fzf owns the pane and the pane exits
+# with it, so quitting never kills anything.
+set -uo pipefail
+
+WORKSPACE=${TMUX_SLACK_LATER_WORKSPACE:-}
+# umask 077 in a per-user TMPDIR: the snapshot is real Later content, so it
+# never lands in a shared path or a repo fixture.
+SNAP="${TMPDIR:-/tmp}/tmux-slack-later-pane.json"
+# fzf runs every bind through `sh -c`, so the re-entry command has to be one a
+# shell can actually execute. $0 alone is not: this file lives in the nix store
+# with no executable bit, and the wrapper reaches it as an argument to bash.
+# Naming that bash explicitly also skips a PATH lookup for our own name.
+self="${BASH:-bash} \"$0\""
+
+# One list call per view change, not per subcommand: --list and --header run off
+# the same snapshot, so the header cannot claim a count the rows disagree with.
+snapshot() {
+  local tmp
+  umask 077
+  tmp=$(mktemp "$SNAP.XXXXXX") || return 1
+  if tmux-slack-later-list >"$tmp" 2>/dev/null &&
+    jq -e 'type == "object"' "$tmp" >/dev/null 2>&1; then
+    mv "$tmp" "$SNAP"
+  else
+    rm -f "$tmp"
+    printf '{"counts":{},"items":[],"error":"unavailable","truncated":false}' >"$SNAP"
+  fi
+}
+
+# Emits "<url>\t<display>"; fzf shows field 2 and the binds consume {1}. clean
+# strips C0 and DEL first: titles are attacker-controlled (anyone who can DM you
+# can put an ESC in one) and this pane is the only thing between a Slack message
+# and the terminal's escape parser. Our dim/red codes are added after, so they
+# are the only escapes that reach the screen.
+render() {
+  jq -r '
+    def clean: tostring | gsub("[\u0000-\u001f\u007f]"; " ") | gsub(" {2,}"; " ") | ltrimstr(" ");
+    def dim: "\u001b[2m" + . + "\u001b[0m";
+    def red: "\u001b[31m" + . + "\u001b[0m";
+    def epoch:
+      if type == "number" then .
+      elif type == "string" and test("^[0-9]+(\\.[0-9]+)?$") then tonumber
+      else (. as $v | try ($v | fromdateiso8601) catch null)
+      end;
+
+    (.items // [])
+    | if type == "array" then .[] else empty end
+    | select(type == "object")
+    | ((.date_due | epoch) as $d | $d != null and $d > 0 and $d < now) as $overdue
+    | [ (.url // "" | tostring),
+        ( (if $overdue then ("! " | red) else "" end)
+          + ((.title // "") | clean | if length == 0 then ("untitled" | dim) else . end) )
+      ]
+    | @tsv
+  ' "$SNAP" 2>/dev/null
+}
+
+# Says which nothing this is — an empty list and a failed read look identical
+# otherwise. Field 1 is empty, so enter on a placeholder is a no-op.
+placeholder() {
+  local error
+  error=$(jq -r '(.error // "") | tostring | gsub("[^a-zA-Z0-9 _-]"; "")' "$SNAP" 2>/dev/null) || error=""
+  if [ -n "$error" ]; then
+    printf '\033[2mcould not load Later (%s) — r to retry\033[0m' "$error"
+  else
+    printf '\033[2mnothing saved for later\033[0m'
+  fi
+}
+
+# "Later · 12 · 10 shown · truncated · ⚠ credentials". The tally shows only when
+# it disagrees with the count and the warning only when there is one: a header
+# that is always full is a header nobody reads.
+header_line() {
+  local n shown truncated error extra=""
+  # Tab is IFS whitespace, so `read` collapses a run of them: an empty field in
+  # the middle would shift every field after it left, and the error would
+  # silently arrive in `truncated`. Only the last field is allowed to be empty.
+  IFS=$'\t' read -r n shown truncated error <<<"$(jq -r '
+    [ (.counts.uncompleted_count // 0),
+      ((.items // []) | if type == "array" then length else 0 end),
+      (if .truncated == true then "1" else "0" end),
+      ((.error // "") | tostring | gsub("[^a-zA-Z0-9 _-]"; "")) ]
+    | @tsv
+  ' "$SNAP" 2>/dev/null)"
+  case "${n:-}" in "" | *[!0-9]*) n=0 ;; esac
+  case "${shown:-}" in "" | *[!0-9]*) shown=0 ;; esac
+  [ "$shown" = "$n" ] || extra=" · $shown shown"
+  [ "${truncated:-0}" != 1 ] || extra="$extra · truncated"
+  [ -z "${error:-}" ] || extra="$extra · ⚠ $error"
+  printf 'Later · %s%s\n' "$n" "$extra"
+  printf 'enter open · / search · r refresh · q quit\n'
+}
+
+# Only the exact configured workspace host, or Slack's own app scheme. The
+# leading-anchored patterns make "https://evil.test@workspace/..." fail, and an
+# unset workspace fails closed rather than trusting every https url.
+valid_url() {
+  case "$1" in
+    *[[:cntrl:][:space:]]* | "") return 1 ;;
+  esac
+  [ -n "$WORKSPACE" ] || case "$1" in slack://*) return 0 ;; *) return 1 ;; esac
+  case "$1" in
+    "https://$WORKSPACE" | "https://$WORKSPACE/"* | slack://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+case "${1:-}" in
+  --list)
+    rows=$(render)
+    [ -n "$rows" ] || rows=$'\t'"$(placeholder)"
+    printf '%s\n' "$rows"
+    exit 0
+    ;;
+  --header)
+    header_line
+    exit 0
+    ;;
+  --refresh)
+    tmux-slack-later-refresh >/dev/null 2>&1 || true
+    snapshot
+    exit 0
+    ;;
+  --open)
+    valid_url "${2:-}" || exit 0
+    open "$2" >/dev/null 2>&1 || true
+    exit 0
+    ;;
+esac
+
+snapshot
+list=$(render)
+[ -n "$list" ] || list=$'\t'"$(placeholder)"
+
+redraw='reload('"$self"' --list)+transform-header('"$self"' --header)'
+# shellcheck disable=SC2016  # {1} is fzf's placeholder (shell-quoted by fzf)
+b_open='execute-silent('"$self"' --open {1})'
+b_refresh='execute-silent('"$self"' --refresh)+'"$redraw"
+# Menu mode by default, `/` for search — the PR popup's two modes. With search
+# live from the start, q and r are letters you could not type, so they come off
+# for the duration of a query; change:clear-query wipes the letters --disabled
+# would otherwise silently collect in menu mode.
+b_search='unbind(change)+unbind(q)+unbind(r)+unbind(/)+clear-query+change-prompt(/ )+enable-search'
+b_esc_back='clear-query+disable-search+change-prompt(❯ )+rebind(change)+rebind(q)+rebind(r)+rebind(/)+'"$redraw"
+# shellcheck disable=SC2016  # $FZF_PROMPT is fzf's variable, not bash's
+b_esc='transform~[ "$FZF_PROMPT" = "/ " ] && echo "'"$b_esc_back"'" || echo abort~'
+
+printf '%s\n' "$list" | fzf \
+  --ansi --no-sort --layout=reverse --cycle \
+  --delimiter='\t' --with-nth=2 \
+  --disabled \
+  --prompt='❯ ' \
+  --info=inline-right \
+  --pointer='▶' \
+  --gutter=' ' \
+  --color='pointer:green,prompt:green,info:dim,header:dim' \
+  --header="$(header_line)" \
+  --bind "enter:$b_open" \
+  --bind "r:$b_refresh" \
+  --bind "/:$b_search" \
+  --bind 'change:clear-query' \
+  --bind 'q:abort' \
+  --bind 'ctrl-c:abort' \
+  --bind "esc:$b_esc"

--- a/modules/chat/slack/later-pane.sh
+++ b/modules/chat/slack/later-pane.sh
@@ -10,6 +10,9 @@ WORKSPACE=${TMUX_SLACK_LATER_WORKSPACE:-}
 # umask 077 in a per-user TMPDIR: the snapshot is real Later content, so it
 # never lands in a shared path or a repo fixture.
 SNAP="${TMPDIR:-/tmp}/tmux-slack-later-pane.json"
+# Set once the pane's first real backend load has been kicked off, so the `load`
+# event can tell that one from every later one without fzf keeping state for us.
+LOADED="$SNAP.loaded"
 # fzf runs every bind through `sh -c`, so the re-entry command has to be one a
 # shell can actually execute. $0 alone is not: this file lives in the nix store
 # with no executable bit, and the wrapper reaches it as an argument to bash.
@@ -18,11 +21,17 @@ self="${BASH:-bash} \"$0\""
 
 # One list call per view change, not per subcommand: --list and --header run off
 # the same snapshot, so the header cannot claim a count the rows disagree with.
+# Args are forwarded: `snapshot --cached` takes whatever the backend already has
+# without waiting for a fetch.
 snapshot() {
   local tmp
   umask 077
   tmp=$(mktemp "$SNAP.XXXXXX") || return 1
-  if tmux-slack-later-list >"$tmp" 2>/dev/null &&
+  # fzf kills a reader it has superseded, and this one is holding real Later
+  # content in a half-written file.
+  # shellcheck disable=SC2064  # expanding now is the point: $tmp is local
+  trap "rm -f '$tmp'" EXIT HUP INT TERM
+  if tmux-slack-later-list "$@" >"$tmp" 2>/dev/null &&
     jq -e 'type == "object"' "$tmp" >/dev/null 2>&1; then
     mv "$tmp" "$SNAP"
   else
@@ -64,11 +73,11 @@ render() {
 placeholder() {
   local error
   error=$(jq -r '(.error // "") | tostring | gsub("[^a-zA-Z0-9 _-]"; "")' "$SNAP" 2>/dev/null) || error=""
-  if [ -n "$error" ]; then
-    printf '\033[2mcould not load Later (%s) — r to retry\033[0m' "$error"
-  else
-    printf '\033[2mnothing saved for later\033[0m'
-  fi
+  case "$error" in
+    "") printf '\033[2mnothing saved for later\033[0m' ;;
+    loading) printf '\033[2mloading Later…\033[0m' ;;
+    *) printf '\033[2mcould not load Later (%s) — r to retry\033[0m' "$error" ;;
+  esac
 }
 
 # "Later · 12 · 10 shown · truncated · ⚠ credentials". The tally shows only when
@@ -90,7 +99,12 @@ header_line() {
   case "${shown:-}" in "" | *[!0-9]*) shown=0 ;; esac
   [ "$shown" = "$n" ] || extra=" · $shown shown"
   [ "${truncated:-0}" != 1 ] || extra="$extra · truncated"
-  [ -z "${error:-}" ] || extra="$extra · ⚠ $error"
+  # A fetch in flight is not a failure: no ⚠, just a count that is not final.
+  case "${error:-}" in
+    "") ;;
+    loading) extra="$extra · loading…" ;;
+    *) extra="$extra · ⚠ $error" ;;
+  esac
   printf 'Later · %s%s\n' "$n" "$extra"
   printf 'enter open · / search · r refresh · q quit\n'
 }
@@ -110,7 +124,10 @@ valid_url() {
 }
 
 case "${1:-}" in
-  --list)
+  # --load is --list with the real backend call in front of it: the fetch fzf
+  # runs behind the cached rows once they are already on screen.
+  --list | --load)
+    [ "$1" = --list ] || snapshot
     rows=$(render)
     [ -n "$rows" ] || rows=$'\t'"$(placeholder)"
     printf '%s\n' "$rows"
@@ -118,6 +135,20 @@ case "${1:-}" in
     ;;
   --header)
     header_line
+    exit 0
+    ;;
+  # fzf fires `load` after every list it finishes reading. The first one is the
+  # cached snapshot, and answers with the fetch that replaces it; every later
+  # one is a finished fetch, and answers with the header it left behind. Both
+  # are printed for fzf's `transform`, which runs whatever actions it is given.
+  --loaded)
+    # A marker we cannot write answers as if the fetch already happened: fzf
+    # loads what a reload delivers, so a reload it can never mark down is a loop.
+    if [ -e "$LOADED" ] || ! : 2>/dev/null >"$LOADED"; then
+      printf 'transform-header(%s --header)' "$self"
+    else
+      printf 'reload-sync(%s --load)' "$self"
+    fi
     exit 0
     ;;
   --refresh)
@@ -132,7 +163,11 @@ case "${1:-}" in
     ;;
 esac
 
-snapshot
+# Whatever the backend already has, with no fetch in the way: a cache that is
+# stale, or missing entirely, still gives fzf something to be interactive with
+# on the first frame. The fetch happens under the `load` bind below.
+rm -f "$LOADED"
+snapshot --cached
 list=$(render)
 [ -n "$list" ] || list=$'\t'"$(placeholder)"
 
@@ -145,9 +180,15 @@ b_refresh='execute-silent('"$self"' --refresh)+'"$redraw"
 # for the duration of a query; change:clear-query wipes the letters --disabled
 # would otherwise silently collect in menu mode.
 b_search='unbind(change)+unbind(q)+unbind(r)+unbind(/)+clear-query+change-prompt(/ )+enable-search'
-b_esc_back='clear-query+disable-search+change-prompt(❯ )+rebind(change)+rebind(q)+rebind(r)+rebind(/)+'"$redraw"
+b_esc_back='clear-query+disable-search+change-prompt(❯ )+rebind(change)+rebind(q)+rebind(r)+rebind(/)'
 # shellcheck disable=SC2016  # $FZF_PROMPT is fzf's variable, not bash's
 b_esc='transform~[ "$FZF_PROMPT" = "/ " ] && echo "'"$b_esc_back"'" || echo abort~'
+# search() re-matches every row, which a cleared query no longer does once
+# search is off, and it has to ride on the bind: emitted from the transform,
+# fzf ignores it. It stands in for the reload that used to end this path, which
+# killed the first load still fetching — with the marker down, nothing would
+# start another. On the abort branch fzf is quitting, so it lands nowhere.
+b_esc="$b_esc+search()"
 
 printf '%s\n' "$list" | fzf \
   --ansi --no-sort --layout=reverse --cycle \
@@ -159,6 +200,7 @@ printf '%s\n' "$list" | fzf \
   --gutter=' ' \
   --color='pointer:green,prompt:green,info:dim,header:dim' \
   --header="$(header_line)" \
+  --bind "load:transform($self --loaded)" \
   --bind "enter:$b_open" \
   --bind "r:$b_refresh" \
   --bind "/:$b_search" \

--- a/modules/chat/slack/later-pane.test.sh
+++ b/modules/chat/slack/later-pane.test.sh
@@ -124,6 +124,12 @@ check "an empty list says it is empty" "$(run --list | plain | cut -f2)" \
   "nothing saved for later"
 check "the empty placeholder carries no url" "$(run --list | cut -f1)" ""
 
+snapshot '{"counts":{"uncompleted_count":0},"items":[],"error":"loading","truncated":false}'
+check "a first frame with no cache says so" "$(run --list | plain | cut -f2)" \
+  "loading Later…"
+check "a fetch in flight is not dressed as a failure" "$(run --header | head -1)" \
+  "Later · 0 · loading…"
+
 snapshot '{"counts":{"uncompleted_count":0},"items":[],"error":"credentials","truncated":false}'
 check "a failed read does not pose as an empty list" "$(run --list | plain | cut -f2)" \
   "could not load Later (credentials) — r to retry"
@@ -195,6 +201,73 @@ check "r refreshes the backend cache before re-listing" \
 check "r then re-reads the list" \
   "$(grep -c 'tmux-slack-later-list' "$CALLED")" "1"
 check "refresh leaves a usable snapshot" "$(run --header | head -1)" "Later · 1"
+
+# ── the first frame ───────────────────────────────────────────────────────
+# The backend's own list refreshes a stale cache before it answers, which is a
+# network round trip the pane used to sit through with nothing on screen. So the
+# pane must reach fzf off `--cached` alone and let fzf run the slow call behind
+# the rows that are already up. This backend takes 3 seconds to answer anything
+# but --cached, so a pane that still waits for it cannot pass on time.
+cat >"$SANDBOX/bin/tmux-slack-later-list" <<EOF
+#!/bin/sh
+printf '%s\n' "list \$*" >>"$CALLED"
+if [ "\$1" = --cached ]; then
+  printf '{"counts":{"uncompleted_count":1},"items":[{"id":"c","title":"from cache","url":""}],"error":"","truncated":false}'
+else
+  sleep 3
+  printf '{"counts":{"uncompleted_count":2},"items":[{"id":"f","title":"from Slack","url":""},{"id":"g","title":"also fresh","url":""}],"error":"","truncated":false}'
+fi
+EOF
+chmod +x "$SANDBOX/bin/tmux-slack-later-list"
+cat >"$SANDBOX/bin/fzf" <<EOF
+#!/bin/sh
+cat >"$SANDBOX/fzfstdin"
+printf '%s\n' "\$@" >"$SANDBOX/fzfargs"
+EOF
+chmod +x "$SANDBOX/bin/fzf"
+
+: >"$CALLED"
+started=$(date +%s)
+run >/dev/null
+elapsed=$(($(date +%s) - started))
+check "fzf starts before the slow backend answers" "$((elapsed < 3))" "1"
+check "the first frame costs exactly one cached call" \
+  "$(sort "$CALLED" | uniq -c | tr -s ' ' | sed 's/^ //')" "1 list --cached"
+check "the rows fzf opens with are the cached ones" \
+  "$(plain <"$SANDBOX/fzfstdin" | cut -f2)" "from cache"
+check "the header fzf opens with matches them" \
+  "$(grep -c '^--header=Later · 1$' "$SANDBOX/fzfargs")" "1"
+
+# fzf re-asks on every load it finishes: the first answer fetches, the rest read
+# back the header that fetch left behind. Without that turn the pane would loop
+# reloading itself, and without the marker every reload would refetch.
+loadbind=$(sed -n 's/^load:transform(\(.*\))$/\1/p' "$SANDBOX/fzfargs")
+check "the load event is wired to the pane" \
+  "$([ -n "$loadbind" ] && echo yes)" "yes"
+# Restarting the reader kills whatever it is still reading, so a redraw on the
+# way out of search would abort that first load and, with the marker already
+# down, nothing would start another. Refresh may do it — the user asked.
+check "leaving search does not abort the load" \
+  "$(grep -c '^esc:.*reload' "$SANDBOX/fzfargs")" "0"
+first=$(PATH="$SANDBOX/bin:$PATH" TMPDIR="$SANDBOX" TMUX_SLACK_LATER_WORKSPACE="$WORKSPACE" \
+  sh -c "$loadbind" 2>/dev/null)
+second=$(PATH="$SANDBOX/bin:$PATH" TMPDIR="$SANDBOX" TMUX_SLACK_LATER_WORKSPACE="$WORKSPACE" \
+  sh -c "$loadbind" 2>/dev/null)
+check "the first load asks fzf for the real list" \
+  "$(printf '%s' "$first" | sed 's/(.*--/(--/')" "reload-sync(--load)"
+check "a later load only re-reads the header" \
+  "$(printf '%s' "$second" | sed 's/(.*--/(--/')" "transform-header(--header)"
+
+# What that reload actually delivers: the rows fzf swaps in, and the header the
+# following load event then reads out of the snapshot it left.
+loadcmd=$(printf '%s' "$first" | sed 's/^reload-sync(//; s/)$//')
+: >"$CALLED"
+fresh=$(PATH="$SANDBOX/bin:$PATH" TMPDIR="$SANDBOX" TMUX_SLACK_LATER_WORKSPACE="$WORKSPACE" \
+  sh -c "$loadcmd" 2>/dev/null | plain | cut -f2 | tr '\n' '|')
+check "the async load calls the real backend" "$(cat "$CALLED")" "list "
+check "the async load returns the fetched rows" "$fresh" "from Slack|also fresh|"
+check "the header follows the rows it loaded" "$(run --header | head -1)" "Later · 2"
+rm -f "$SANDBOX/bin/fzf"
 
 if ((fail)); then
   echo "FAILED"

--- a/modules/chat/slack/later-pane.test.sh
+++ b/modules/chat/slack/later-pane.test.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Self-check for the Later pane's rendering and its url gate. Drives
+# later-pane.sh directly with a fixture snapshot and fake list/refresh/open
+# binaries on PATH, so it never opens Chrome, the keychain or the network.
+#
+# The url gate is the part worth pinning: every row here came from a Slack
+# message somebody else wrote, so "enter opens the selected url" is a hostile
+# input path. A regression that lets one extra url shape through still renders
+# perfectly and errors nowhere.
+#
+# Run by hand: bash later-pane.test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PANE="$HERE/later-pane.sh"
+WORKSPACE=example.slack.com
+
+[[ -f "$PANE" ]] || {
+  echo "FAIL: $PANE not found"
+  exit 1
+}
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/bin"
+OPENED="$SANDBOX/opened"
+CALLED="$SANDBOX/called"
+
+for fake in open tmux-slack-later-refresh tmux-slack-later-list; do
+  printf '#!/bin/sh\nprintf "%%s\\n" "%s $*" >>"%s"\n' "$fake" "$CALLED" >"$SANDBOX/bin/$fake"
+  chmod +x "$SANDBOX/bin/$fake"
+done
+# open is the one fake with its own log: the tests below assert on exactly
+# which urls reached it, not merely that something ran.
+cat >"$SANDBOX/bin/open" <<EOF
+#!/bin/sh
+printf '%s\n' "\$1" >>"$OPENED"
+EOF
+chmod +x "$SANDBOX/bin/open"
+# The list fake must emit valid JSON or --refresh's snapshot falls back to its
+# error shape, which would make the refresh assertion pass for the wrong reason.
+cat >"$SANDBOX/bin/tmux-slack-later-list" <<EOF
+#!/bin/sh
+printf '%s\n' "tmux-slack-later-list" >>"$CALLED"
+printf '{"counts":{"uncompleted_count":1},"items":[{"id":"x","title":"fresh","url":""}],"error":"","truncated":false}'
+EOF
+chmod +x "$SANDBOX/bin/tmux-slack-later-list"
+
+fail=0
+snapshot() { printf '%s' "$1" >"$SANDBOX/tmux-slack-later-pane.json"; }
+
+run() {
+  PATH="$SANDBOX/bin:$PATH" TMPDIR="$SANDBOX" TMUX_SLACK_LATER_WORKSPACE="$WORKSPACE" \
+    bash "$PANE" "$@" 2>/dev/null
+}
+
+# Strips the pane's own SGR codes; only text, ordering and marks are asserted.
+plain() { sed 's/\x1b\[[0-9;]*m//g'; }
+
+check() {
+  local label=$1 got=$2 want=$3
+  if [[ "$got" == "$want" ]]; then
+    printf 'ok: %s\n' "$label"
+  else
+    printf 'FAIL: %s\n  expected: %q\n  got:      %q\n' "$label" "$want" "$got"
+    fail=1
+  fi
+}
+
+now=$(date +%s)
+past=$((now - 86400))
+future=$((now + 86400))
+
+full=$(
+  cat <<EOF
+{"counts":{"uncompleted_count":3,"uncompleted_overdue_count":1},
+ "items":[
+   {"id":"Sm001","title":"ship the migration","url":"https://$WORKSPACE/archives/C1/p1","date_created":$past,"date_due":$past},
+   {"id":"Sm002","title":"read the RFC","url":"https://$WORKSPACE/archives/C1/p2","date_created":$past,"date_due":$future},
+   {"id":"Sm003","title":"no due date","url":"https://$WORKSPACE/archives/C1/p3","date_created":$past,"date_due":null}],
+ "error":"","truncated":false}
+EOF
+)
+
+# ── header ────────────────────────────────────────────────────────────────
+snapshot "$full"
+check "header leads with the count" "$(run --header | head -1)" "Later · 3"
+check "header advertises its keys" "$(run --header | sed -n 2p)" \
+  "enter open · / search · r refresh · q quit"
+
+snapshot '{"counts":{"uncompleted_count":9},"items":[{"id":"a","title":"t","url":""}],"error":"","truncated":true}'
+check "a partial load says how much of it is on screen" "$(run --header | head -1)" \
+  "Later · 9 · 1 shown · truncated"
+
+snapshot '{"counts":{"uncompleted_count":2},"items":[{"id":"a","title":"t","url":""},{"id":"b","title":"u","url":""}],"error":"credentials","truncated":false}'
+check "a stale read is admitted in the header" "$(run --header | head -1)" \
+  "Later · 2 · ⚠ credentials"
+
+# A malformed error must not become a second escape channel into the header.
+snapshot '{"counts":{"uncompleted_count":0},"items":[],"error":"\u001b[31mfake\u0007","truncated":false}'
+check "header error text is stripped to safe characters" "$(run --header | head -1)" \
+  "Later · 0 · ⚠ 31mfake"
+
+# ── rows ──────────────────────────────────────────────────────────────────
+snapshot "$full"
+check "rows show titles, never ids" "$(run --list | plain | cut -f2 | tr '\n' '|')" \
+  "! ship the migration|read the RFC|no due date|"
+check "row carries its url out of band for the binds" "$(run --list | head -1 | cut -f1)" \
+  "https://$WORKSPACE/archives/C1/p1"
+check "no opaque id reaches the screen" \
+  "$(run --list | cut -f2 | grep -c 'Sm00')" "0"
+
+# Anyone who can DM you can put an ESC in a title; this pane is the last thing
+# before the terminal's escape parser.
+snapshot "{\"counts\":{\"uncompleted_count\":1},\"items\":[{\"id\":\"x\",\"title\":\"pwn\u001b[31m\u0007\u001b]0;title\u0007ed\",\"url\":\"https://$WORKSPACE/a\"}],\"error\":\"\",\"truncated\":false}"
+check "control characters never survive into a row" \
+  "$(run --list | cut -f2 | grep -c $'\x1b\|\x07')" "0"
+check "the sanitized title is still readable" "$(run --list | plain | cut -f2)" \
+  "pwn [31m ]0;title ed"
+
+# ── placeholders ──────────────────────────────────────────────────────────
+snapshot '{"counts":{"uncompleted_count":0},"items":[],"error":"","truncated":false}'
+check "an empty list says it is empty" "$(run --list | plain | cut -f2)" \
+  "nothing saved for later"
+check "the empty placeholder carries no url" "$(run --list | cut -f1)" ""
+
+snapshot '{"counts":{"uncompleted_count":0},"items":[],"error":"credentials","truncated":false}'
+check "a failed read does not pose as an empty list" "$(run --list | plain | cut -f2)" \
+  "could not load Later (credentials) — r to retry"
+check "the error placeholder carries no url" "$(run --list | cut -f1)" ""
+
+# ── the url gate ──────────────────────────────────────────────────────────
+: >"$OPENED"
+for bad in \
+  "" \
+  "http://$WORKSPACE/a" \
+  "https://evil.test/a" \
+  "https://evil.test@$WORKSPACE/a" \
+  "https://$WORKSPACE.evil.test/a" \
+  "https://sub.$WORKSPACE/a" \
+  "file:///etc/passwd" \
+  "javascript:alert(1)" \
+  "$WORKSPACE/a" \
+  "https://$WORKSPACE/a b" \
+  $'https://'"$WORKSPACE"$'/a\nhttps://evil.test'; do
+  run --open "$bad"
+done
+check "every untrusted url shape is refused" "$(wc -l <"$OPENED" | tr -d ' ')" "0"
+
+: >"$OPENED"
+run --open "https://$WORKSPACE/archives/C1/p1"
+run --open "https://$WORKSPACE"
+run --open "slack://channel?team=T1&id=C1"
+check "the configured workspace and slack:// still open" "$(wc -l <"$OPENED" | tr -d ' ')" "3"
+
+# A placeholder row hands the bind an empty field 1, which must stay a no-op.
+: >"$OPENED"
+snapshot '{"counts":{"uncompleted_count":0},"items":[],"error":"","truncated":false}'
+run --open "$(run --list | cut -f1)"
+check "enter on a placeholder opens nothing" "$(wc -l <"$OPENED" | tr -d ' ')" "0"
+
+# With no workspace configured the gate fails closed rather than trusting https.
+: >"$OPENED"
+PATH="$SANDBOX/bin:$PATH" TMPDIR="$SANDBOX" TMUX_SLACK_LATER_WORKSPACE="" \
+  bash "$PANE" --open "https://$WORKSPACE/a" 2>/dev/null
+check "an unconfigured workspace opens no https url" "$(wc -l <"$OPENED" | tr -d ' ')" "0"
+
+# ── re-entry ──────────────────────────────────────────────────────────────
+# Every bind re-invokes this script through fzf's `sh -c`. In the nix store the
+# file has no executable bit and the wrapper reaches it as an argument to bash,
+# so a bare $0 re-entry command fails — and only after a keypress, never on the
+# first render, which is exactly the shape of bug a screenshot does not catch.
+cat >"$SANDBOX/bin/fzf" <<EOF
+#!/bin/sh
+cat >/dev/null
+printf '%s\n' "\$@" >"$SANDBOX/fzfargs"
+EOF
+chmod +x "$SANDBOX/bin/fzf"
+chmod -x "$PANE" 2>/dev/null || true
+
+run >/dev/null
+reentry=$(sed -n 's/.*reload(\(.*\) --list).*/\1/p' "$SANDBOX/fzfargs" | head -1)
+check "the binds re-enter through a runnable command" \
+  "$([ -n "$reentry" ] && echo yes)" "yes"
+check "that command works without an executable bit" \
+  "$(PATH="$SANDBOX/bin:$PATH" TMPDIR="$SANDBOX" TMUX_SLACK_LATER_WORKSPACE="$WORKSPACE" \
+    sh -c "$reentry --header" 2>/dev/null | head -1)" "Later · 1"
+rm -f "$SANDBOX/bin/fzf"
+
+# ── refresh ───────────────────────────────────────────────────────────────
+: >"$CALLED"
+run --refresh
+check "r refreshes the backend cache before re-listing" \
+  "$(grep -c 'tmux-slack-later-refresh' "$CALLED")" "1"
+check "r then re-reads the list" \
+  "$(grep -c 'tmux-slack-later-list' "$CALLED")" "1"
+check "refresh leaves a usable snapshot" "$(run --header | head -1)" "Later · 1"
+
+if ((fail)); then
+  echo "FAILED"
+  exit 1
+fi
+echo "All Later pane checks passed."

--- a/modules/chat/slack/later.nix
+++ b/modules/chat/slack/later.nix
@@ -1,0 +1,121 @@
+# Slack "Later" as an ambient count in the tmux bar.
+#
+# There is no supported Later API. The widget is therefore deliberately opt-in
+# and uses only the dedicated Chrome profile at
+# ~/.local/share/tmux-slack-later/chrome/Default. It never reads desktop Slack
+# or a regular Chrome profile, and a failed extraction is not evidence that
+# Chrome or Slack signed out.
+{ pkgs, lib }:
+{
+  default = false;
+
+  # lib comes from the module args, NOT pkgs.lib: an option DECLARATION that
+  # forces pkgs is circular here (pkgs needs nixpkgs.overlays, which needs the
+  # declarations complete), and nix reports it only as "infinite recursion".
+  extraOptions.workspace = lib.mkOption {
+    type = lib.types.str;
+    default = "";
+    example = "telepatiaworkspace.slack.com";
+    description = ''
+      Exact Slack workspace domain the Later count belongs to. It is checked
+      against auth.test's URL host before any saved.list result is published.
+      An empty or non-matching domain fails closed.
+    '';
+  };
+
+  home =
+    {
+      cfg,
+      lib,
+      userCfg,
+      ...
+    }:
+    let
+      runtimeInputs = with pkgs; [
+        coreutils
+        curl
+        findutils
+        gnugrep
+        jq
+        openssl
+        sqlite
+      ];
+
+      tmux-slack-later-refresh = pkgs.writeShellApplication {
+        name = "tmux-slack-later-refresh";
+        inherit runtimeInputs;
+        text = ''
+          export TMUX_SLACK_LATER_PROFILE="$HOME/.local/share/tmux-slack-later/chrome/Default"
+          export TMUX_SLACK_LATER_WORKSPACE=${lib.escapeShellArg cfg.workspace}
+          exec ${pkgs.bash}/bin/bash ${./later.sh} refresh "$@"
+        '';
+      };
+
+      tmux-slack-later-widget = pkgs.writeShellApplication {
+        name = "tmux-slack-later-widget";
+        runtimeInputs = runtimeInputs ++ [ tmux-slack-later-refresh ];
+        text = ''
+          export TMUX_SLACK_LATER_PROFILE="$HOME/.local/share/tmux-slack-later/chrome/Default"
+          export TMUX_SLACK_LATER_WORKSPACE=${lib.escapeShellArg cfg.workspace}
+          exec ${pkgs.bash}/bin/bash ${./later.sh} widget "$@"
+        '';
+      };
+
+      # Same profile and workspace as refresh, deliberately: a list scoped
+      # differently from the count it sits under would be a different inbox
+      # wearing the same number.
+      tmux-slack-later-list = pkgs.writeShellApplication {
+        name = "tmux-slack-later-list";
+        inherit runtimeInputs;
+        text = ''
+          export TMUX_SLACK_LATER_PROFILE="$HOME/.local/share/tmux-slack-later/chrome/Default"
+          export TMUX_SLACK_LATER_WORKSPACE=${lib.escapeShellArg cfg.workspace}
+          exec ${pkgs.bash}/bin/bash ${./later.sh} list "$@"
+        '';
+      };
+
+      # The pane needs the workspace to decide which urls it is allowed to
+      # hand to the desktop opener; it never reads the profile or the network.
+      tmux-slack-later-pane = pkgs.writeShellApplication {
+        name = "tmux-slack-later-pane";
+        runtimeInputs = with pkgs; [
+          coreutils
+          fzf
+          jq
+          tmux-slack-later-list
+          tmux-slack-later-refresh
+        ];
+        text = ''
+          export TMUX_SLACK_LATER_WORKSPACE=${lib.escapeShellArg cfg.workspace}
+          exec ${pkgs.bash}/bin/bash ${./later-pane.sh} "$@"
+        '';
+      };
+    in
+    {
+      home.packages = lib.optionals userCfg.tmux.enable [
+        tmux-slack-later-refresh
+        tmux-slack-later-widget
+        tmux-slack-later-list
+        tmux-slack-later-pane
+      ];
+
+      # A real split, not a popup: the Later list is something you read while
+      # working, and a popup dies the moment you touch the pane behind it.
+      # Uppercase L only overrides tmux's default switch-client -l; lowercase l
+      # stays lazygit's split. fzf owns the pane, so exiting fzf closes it —
+      # nothing here kills a pane.
+      programs.tmux.extraConfig = lib.mkIf userCfg.tmux.enable ''
+        bind-key L split-window -h -p 40 '${tmux-slack-later-pane}/bin/tmux-slack-later-pane'
+      '';
+
+      # 47 keeps it beside the other attention counts — PR (45) and todoist
+      # (46) — and left of the machine gauges, cpu (50) and disk (55).
+      xdg.configFile."tmux/widgets/47-slack" = lib.mkIf userCfg.tmux.enable {
+        executable = true;
+        text = ''
+          #!/usr/bin/env bash
+          exec ${tmux-slack-later-widget}/bin/tmux-slack-later-widget "$@"
+        '';
+      };
+    };
+}

--- a/modules/chat/slack/later.sh
+++ b/modules/chat/slack/later.sh
@@ -1,0 +1,614 @@
+#!/usr/bin/env bash
+# Offline-safe Slack Later refresh/widget implementation. The Nix wrappers set
+# PROFILE and WORKSPACE; tests can override the cache roots without opening
+# Chrome, the keychain, or the network.
+set -uo pipefail
+
+PROFILE=${TMUX_SLACK_LATER_PROFILE:-}
+WORKSPACE=${TMUX_SLACK_LATER_WORKSPACE:-}
+CACHE_ROOT=${TMUX_SLACK_LATER_CACHE_ROOT:-"${XDG_CACHE_HOME:-$HOME/.cache}/tmux-slack-later"}
+PRIVATE_TMP=
+WORKSPACE=${WORKSPACE,,}
+CONFIG_ERROR=
+case "$WORKSPACE" in
+  *[!a-z0-9.-]* | "") CONFIG_ERROR=workspace ;;
+esac
+[[ -n "$PROFILE" ]] || CONFIG_ERROR=profile
+NAMESPACE=
+CACHE=
+
+configure() {
+  [[ -z "$CONFIG_ERROR" ]] || return 1
+  NAMESPACE=$(printf '%s\0%s' "$PROFILE" "$WORKSPACE" | sha256sum | awk '{ print $1 }')
+  CACHE="$CACHE_ROOT/$NAMESPACE.json"
+}
+
+cleanup() {
+  [[ -z "$PRIVATE_TMP" ]] || rm -rf "$PRIVATE_TMP"
+  unset CHROME_SAFE_STORAGE_PASSWORD
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 1' HUP INT TERM
+
+valid_counts() {
+  jq -ce '
+    def count: type == "number" and . >= 0 and floor == .;
+    if (.counts | type == "object")
+      and (.counts.uncompleted_count | count)
+      and (.counts.uncompleted_overdue_count | count)
+    then {
+      uncompleted_count: .counts.uncompleted_count,
+      uncompleted_overdue_count: .counts.uncompleted_overdue_count
+    }
+    else empty
+    end
+  '
+}
+
+valid_list() {
+  jq -ce '
+    def count: type == "number" and . >= 0 and floor == .;
+    def date: . == null or type == "number" or type == "string";
+    def item:
+      type == "object"
+      and (.id | type == "string")
+      and (.title | type == "string")
+      and (.url | type == "string")
+      and (.date_created | date)
+      and (.date_due | date);
+    if (.counts | type == "object")
+      and (.counts.uncompleted_count | count)
+      and (.counts.uncompleted_overdue_count | count)
+      and (.items | type == "array")
+      and all(.items[]; item)
+      and (.error | type == "string")
+      and (.truncated | type == "boolean")
+    then {
+      counts: {
+        uncompleted_count: .counts.uncompleted_count,
+        uncompleted_overdue_count: .counts.uncompleted_overdue_count
+      },
+      items: [.items[] | {
+        id: .id,
+        title: .title,
+        url: .url,
+        date_created: .date_created,
+        date_due: .date_due
+      }],
+      error: .error,
+      truncated: .truncated
+    }
+    else empty
+    end
+  '
+}
+
+empty_list() {
+  jq -cn --arg error "$1" '{
+    counts: { uncompleted_count: 0, uncompleted_overdue_count: 0 },
+    items: [],
+    error: $error,
+    truncated: false
+  }'
+}
+
+write_cache() {
+  local list=$1 output
+  output=$(mktemp "$PRIVATE_TMP/cache.XXXXXX") || return 1
+  if valid_list <<<"$list" >"$output"; then
+    chmod 600 "$output" || return 1
+    mv "$output" "$CACHE"
+  else
+    rm -f "$output"
+    return 1
+  fi
+}
+
+publish() {
+  local list
+  list=$(valid_list) || return 1
+  write_cache "$list"
+}
+
+publish_error() {
+  local reason=$1 counts list
+  counts=$(valid_counts <"$CACHE" 2>/dev/null) || {
+    counts='{"uncompleted_count":0,"uncompleted_overdue_count":0}'
+  }
+  if ! list=$(valid_list <"$CACHE" 2>/dev/null); then
+    list=$(jq -cn --argjson counts "$counts" --arg error "$reason" '{
+      counts: $counts,
+      items: [],
+      error: $error,
+      truncated: false
+    }') || return 1
+  else
+    list=$(jq -c --arg error "$reason" '.error = $error' <<<"$list") || return 1
+  fi
+  write_cache "$list"
+}
+
+cache_fresh() {
+  [[ -f "$CACHE" ]] && find "$CACHE" -mmin -15 2>/dev/null | grep -q .
+}
+
+cache_has_items() {
+  valid_list <"$CACHE" >/dev/null 2>&1
+}
+
+emit_list() {
+  valid_list <"$CACHE" 2>/dev/null || empty_list "cache"
+}
+
+cookie_database() {
+  local candidate
+  for candidate in "$PROFILE/Network/Cookies" "$PROFILE/Cookies"; do
+    [[ -f "$candidate" ]] && {
+      printf '%s' "$candidate"
+      return 0
+    }
+  done
+  return 1
+}
+
+safe_token() {
+  [[ $1 =~ ^xoxc-[0-9A-Za-z-]{20,}$ ]]
+}
+
+safe_jar_field() {
+  [[ $1 != *$'\t'* && $1 != *$'\r'* && $1 != *$'\n'* ]]
+}
+
+cookie_path_matches() {
+  local cookie_path=$1 request_path=$2
+  [[ $cookie_path == /* && $request_path == "$cookie_path"* ]] || return 1
+  [[ $cookie_path == / || $cookie_path == */ || ${request_path:${#cookie_path}:1} == / ]]
+}
+
+workspace_cookie_domain() {
+  local domain=$1 suffix
+  case "$domain" in
+    "$WORKSPACE") return 0 ;;
+    .*)
+      suffix=${domain#.}
+      [[ $WORKSPACE == "$suffix" || $WORKSPACE == *."$suffix" ]]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+derive_key() {
+  local password key security=${TMUX_SLACK_LATER_SECURITY:-/usr/bin/security}
+
+  [[ $security == /* && -x $security ]] || return 1
+  password=$("$security" find-generic-password -w \
+    -s "Chrome Safe Storage" -a "Chrome" 2>/dev/null) || return 1
+  [[ -n "$password" ]] || return 1
+
+  # OpenSSL reads the password from its environment, not a process argument.
+  export CHROME_SAFE_STORAGE_PASSWORD=$password
+  key=$(openssl enc -aes-128-cbc -P -md sha1 -iter 1003 -saltlen 9 \
+    -pass env:CHROME_SAFE_STORAGE_PASSWORD \
+    -S 73616c747973616c74 2>/dev/null | awk -F= '/^key=/{ print $2 }')
+  unset CHROME_SAFE_STORAGE_PASSWORD
+  [[ $key =~ ^[0-9A-Fa-f]{32}$ ]] || return 1
+  printf '%s' "$key"
+}
+
+decrypt_cookie() {
+  local key=$1 db=$2 rowid=$3 domain=$4 schema=$5 blob plaintext domain_hash actual_hash
+
+  [[ $rowid =~ ^[0-9]+$ ]] || return 1
+  blob="$PRIVATE_TMP/cookie-$rowid.blob"
+  plaintext="$PRIVATE_TMP/cookie-$rowid.plaintext"
+  domain_hash="$PRIVATE_TMP/cookie-$rowid.domain.hash"
+  actual_hash="$PRIVATE_TMP/cookie-$rowid.actual.hash"
+  sqlite3 "$db" \
+    "select writefile('$blob', encrypted_value) from cookies where rowid = $rowid;" \
+    >/dev/null 2>&1 || return 1
+  [[ -s "$blob" ]] || return 1
+
+  case "$(head -c 3 "$blob")" in
+    v10 | v11) ;;
+    *) return 1 ;;
+  esac
+
+  # No -nopad: OpenSSL removes PKCS#7 padding normally. Chromium's v24 domain
+  # hash is checked before the cookie value is emitted into the private jar.
+  tail -c +4 "$blob" | openssl enc -aes-128-cbc -d -K "$key" \
+    -iv 20202020202020202020202020202020 >"$plaintext" 2>/dev/null || return 1
+  if (( schema >= 24 )); then
+    printf '%s' "$domain" | openssl dgst -sha256 -binary >"$domain_hash"
+    head -c 32 "$plaintext" >"$actual_hash"
+    cmp -s "$domain_hash" "$actual_hash" || return 1
+    tail -c +33 "$plaintext"
+  else
+    cat "$plaintext"
+  fi
+}
+
+extract_cookie_jar() {
+  local source_db=$1 db jar key schema now_chrome rowid domain path secure expires name value encrypted_len
+  local cookie include_subdomains unix_expiry count=0
+
+  # sqlite's backup API gives a consistent snapshot of Chrome's live database.
+  db="$PRIVATE_TMP/cookies.sqlite"
+  jar="$PRIVATE_TMP/cookies.txt"
+  sqlite3 "$source_db" ".backup '$db'" >/dev/null 2>&1 || return 1
+  schema=$(sqlite3 "$db" "select value from meta where key = 'version';" 2>/dev/null) || return 1
+  [[ $schema =~ ^[0-9]+$ ]] || return 1
+
+  # One Chrome Safe Storage derivation covers every encrypted row in this
+  # extraction. Plaintext rows still enter the same workspace-scoped jar.
+  key=$(derive_key) || return 1
+  now_chrome=$(( $(date +%s) * 1000000 + 11644473600000000 ))
+  printf '# Netscape HTTP Cookie File\n' >"$jar"
+
+  while IFS=$'\x1f' read -r rowid domain path secure expires name value encrypted_len; do
+    workspace_cookie_domain "$domain" || continue
+    cookie_path_matches "$path" /api/ || continue
+    [[ $secure == 0 || $secure == 1 ]] || continue
+    [[ $expires =~ ^[0-9]+$ && $encrypted_len =~ ^[0-9]+$ ]] || continue
+    if [[ -z $name ]] || ! safe_jar_field "$name" || ! safe_jar_field "$value"; then
+      continue
+    fi
+
+    if [[ -n $value ]]; then
+      cookie=$value
+    elif (( encrypted_len > 0 )); then
+      cookie=$(decrypt_cookie "$key" "$db" "$rowid" "$domain" "$schema") || continue
+      safe_jar_field "$cookie" || continue
+    else
+      continue
+    fi
+
+    if [[ $domain == .* ]]; then
+      include_subdomains=TRUE
+    else
+      include_subdomains=FALSE
+    fi
+    if (( expires == 0 )); then
+      unix_expiry=0
+    else
+      (( expires > now_chrome )) || continue
+      unix_expiry=$((expires / 1000000 - 11644473600))
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$domain" "$include_subdomains" "$path" \
+      "$([[ $secure == 1 ]] && printf TRUE || printf FALSE)" \
+      "$unix_expiry" "$name" "$cookie" >>"$jar"
+    ((count += 1))
+  done < <(
+    sqlite3 -separator $'\x1f' "$db" "
+      select rowid, host_key, path, is_secure, expires_utc, name,
+        coalesce(value, ''), length(encrypted_value)
+      from cookies
+      where host_key = '$WORKSPACE'
+        or (substr(host_key, 1, 1) = '.' and '$WORKSPACE' like '%' || host_key)
+      order by length(path) desc, creation_utc asc;
+    " 2>/dev/null
+  )
+
+  (( count > 0 )) || return 1
+  printf '%s' "$jar"
+}
+
+chrome_user_agent() {
+  local version=${TMUX_SLACK_LATER_CHROME_VERSION:-}
+  if [[ -z "$version" ]]; then
+    version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+      '/Applications/Google Chrome.app/Contents/Info.plist' 2>/dev/null) || return 1
+  fi
+  [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+  printf 'Mozilla/5.0 (Macintosh; arm Mac OS X 14_0_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36' "$version"
+}
+
+curl_config_value() {
+  local value=$1
+  [[ $value != *$'\r'* && $value != *$'\n'* ]] || return 1
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  printf '%s' "$value"
+}
+
+# Credentials live only in the private Netscape jar. Curl receives its path in
+# stdin config, while token and cookies never appear in curl's command line.
+slack_request() {
+  local endpoint=$1 token=$2 jar=$3 message_ids=${4:-} user_agent escaped_message_ids
+  safe_token "$token" && [[ -r "$jar" ]] || return 1
+  case "$endpoint" in
+    auth.test | saved.list) ;;
+    messages.list) [[ -n "$message_ids" ]] || return 1 ;;
+    *) return 1 ;;
+  esac
+  user_agent=$(chrome_user_agent) || return 1
+  if [[ $endpoint == messages.list ]]; then
+    escaped_message_ids=$(curl_config_value "$message_ids") || return 1
+  fi
+
+  {
+    cat <<EOF
+url = "https://$WORKSPACE/api/$endpoint"
+request = "POST"
+connect-timeout = 5
+max-time = 15
+user-agent = "$user_agent"
+cookie = "$jar"
+data-urlencode = "token=$token"
+EOF
+    case "$endpoint" in
+      saved.list)
+        cat <<'EOF'
+data-urlencode = "limit=49"
+data-urlencode = "filter=saved"
+EOF
+        ;;
+      messages.list) printf 'data-urlencode = "message_ids=%s"\n' "$escaped_message_ids" ;;
+    esac
+  } | curl --silent --show-error --config -
+}
+
+call_saved() {
+  local response error
+  response=$(slack_request "saved.list" "$1" "$2") || return 2
+  error=$(printf '%s' "$response" | jq -r 'if .ok then "" else (.error // "malformed") end' 2>/dev/null) || return 2
+  case "$error" in
+    "") printf '%s' "$response" ;;
+    invalid_auth | not_authed | token_revoked | token_expired) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+call_messages() {
+  local response error
+  response=$(slack_request "messages.list" "$1" "$2" "$3") || return 1
+  error=$(printf '%s' "$response" | jq -r 'if .ok then "" else (.error // "malformed") end' 2>/dev/null) || return 1
+  [[ -z "$error" ]] || return 1
+  printf '%s' "$response" | jq -ce '.messages | type == "object"' >/dev/null || return 1
+  printf '%s' "$response"
+}
+
+valid_saved_response() {
+  jq -e '
+    def count: type == "number" and . >= 0 and floor == .;
+    .ok == true
+    and (.counts | type == "object")
+    and (.counts.uncompleted_count | count)
+    and (.counts.uncompleted_overdue_count | count)
+    and (.saved_items | type == "array")
+  ' >/dev/null
+}
+
+hydration_batches() {
+  jq -cr '
+    def channel: type == "string" and test("^[A-Z][A-Z0-9]+$");
+    def timestamp: type == "string" and test("^[0-9]+\\.[0-9]+$");
+    [.saved_items[]?
+      | select(.item_type == "message" and (.item_id | channel) and (.ts | timestamp))
+      | { channel: .item_id, timestamp: .ts }]
+    | group_by(.channel)
+    | [range(0; length; 10) as $start
+      | .[$start:($start + 10)]
+      | map({ channel: .[0].channel, timestamps: map(.timestamp) })][]
+  '
+}
+
+materialize_saved() {
+  local saved=$1 messages=$2
+  jq -ce --arg workspace "$WORKSPACE" --slurpfile messages "$messages" '
+    def channel: type == "string" and test("^[A-Z][A-Z0-9]+$");
+    def timestamp: type == "string" and test("^[0-9]+\\.[0-9]+$");
+    def date: type == "number" or type == "string";
+    def clean_title:
+      gsub("<[^>|]+\\|(?<label>[^>]+)>"; "\(.label)")
+      | gsub("[[:cntrl:]]"; " ")
+      | gsub("[[:space:]]+"; " ")
+      | gsub("^[[:space:]]+|[[:space:]]+$"; "")
+      | .[0:300]
+      | if length == 0 then "Message unavailable" else . end;
+    def message_text($channel; $timestamp):
+      [$messages[0][$channel][]?
+        | select((.ts? | type) == "string" and .ts == $timestamp)
+        | .text? | select(type == "string")][0] // "";
+    {
+      counts: {
+        uncompleted_count: .counts.uncompleted_count,
+        uncompleted_overdue_count: .counts.uncompleted_overdue_count
+      },
+      items: [
+        .saved_items | to_entries[]
+        | .key as $index | .value
+        | . as $item
+        | ($item.item_id? // null) as $channel
+        | ($item.ts? // null) as $timestamp
+        | {
+          id: (if ($channel | channel) and ($timestamp | timestamp)
+            then "\($channel):\($timestamp)"
+            else "item:\($index)"
+            end),
+          title: (if $item.item_type == "message"
+              and ($channel | channel) and ($timestamp | timestamp)
+            then message_text($channel; $timestamp) | clean_title
+            else "Message unavailable"
+            end),
+          url: (if $item.item_type == "message"
+              and ($channel | channel) and ($timestamp | timestamp)
+            then "https://\($workspace)/archives/\($channel)/p\($timestamp | gsub("\\."; ""))"
+            else "https://\($workspace)"
+            end),
+          date_created: (if ($item.date_created? | date) then $item.date_created else null end),
+          date_due: (if ($item.date_due? | date) then $item.date_due else null end)
+        }
+      ],
+      error: "",
+      truncated: ((.response_metadata? | type) == "object"
+        and (.response_metadata.next_cursor? | type) == "string"
+        and .response_metadata.next_cursor != "")
+    }
+  ' <<<"$saved"
+}
+
+hydrate_saved() {
+  local token=$1 jar=$2 saved=$3 messages response response_file next
+  valid_saved_response <<<"$saved" || return 1
+  messages="$PRIVATE_TMP/messages.json"
+  printf '{}' >"$messages"
+
+  while IFS= read -r batch; do
+    [[ -n "$batch" ]] || continue
+    response=$(call_messages "$token" "$jar" "$batch") || return 1
+    response_file=$(mktemp "$PRIVATE_TMP/messages-response.XXXXXX") || return 1
+    next="$PRIVATE_TMP/messages-next.json"
+    printf '%s' "$response" >"$response_file"
+    jq -ce -s '.[0] + .[1].messages' "$messages" "$response_file" >"$next" || return 1
+    mv "$next" "$messages"
+  done < <(hydration_batches <<<"$saved")
+
+  materialize_saved "$saved" "$messages"
+}
+
+# Return 0 only for the exact configured URL host; no team-name/id/substrings.
+workspace_ok() {
+  local response
+  response=$(slack_request "auth.test" "$1" "$2") || return 2
+  printf '%s' "$response" | jq -e --arg workspace "$WORKSPACE" '
+    .ok == true
+    and (.url | type == "string")
+    and ((.url | capture("^https://(?<host>[A-Za-z0-9.-]+)(?:/|$)").host | ascii_downcase) == $workspace)
+  ' >/dev/null 2>&1
+}
+
+candidates() {
+  local leveldb=$PROFILE/Local\ Storage/leveldb file
+  [[ -d "$leveldb" ]] || return 0
+  # This is a bounded raw-binary grep, not a LevelDB parser. No result only
+  # means no usable plaintext token was found in this limited scan; it does not
+  # mean Chrome or Slack is signed out.
+  while IFS= read -r file; do
+    grep -a -o -m 16 'xoxc-[0-9A-Za-z-]\{20,\}' "$file" 2>/dev/null
+  done < <(
+    find "$leveldb" -maxdepth 1 -type f \( -name '*.ldb' -o -name '*.log' \) -print 2>/dev/null \
+      | sort | head -n 32
+  ) | sort -u | head -n 8
+}
+
+resolve() {
+  local jar=$1 tokens=$2 token response status
+  while IFS= read -r token; do
+    [[ -n "$token" ]] || continue
+    workspace_ok "$token" "$jar"
+    status=$?
+    case "$status" in
+      0) ;;
+      2) return 2 ;;
+      *) continue ;;
+    esac
+    if response=$(call_saved "$token" "$jar"); then
+      response=$(hydrate_saved "$token" "$jar" "$response") || return 2
+      printf '%s' "$response"
+      return 0
+    else
+      status=$?
+      (( status == 2 )) && return 2
+    fi
+  done <<<"$tokens"
+  return 1
+}
+
+refresh() {
+  local db tokens jar response="" status
+
+  umask 077
+  mkdir -p "$CACHE_ROOT" || return 1
+  chmod 700 "$CACHE_ROOT" || return 1
+  PRIVATE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/tmux-slack-later.XXXXXX") || return 1
+  touch "$CACHE" || return 1
+  chmod 600 "$CACHE" || return 1
+
+  db=$(cookie_database) || {
+    publish_error "profile"
+    return 0
+  }
+  tokens=$(candidates)
+  [[ -n "$tokens" ]] || {
+    publish_error "credentials"
+    return 0
+  }
+  jar=$(extract_cookie_jar "$db") || {
+    publish_error "credentials"
+    return 0
+  }
+
+  if response=$(resolve "$jar" "$tokens"); then
+    publish <<<"$response" || publish_error "response"
+    return 0
+  else
+    status=$?
+  fi
+  (( status == 2 )) && {
+    publish_error "network"
+    return 0
+  }
+  publish_error "credentials"
+}
+
+list() {
+  if ! cache_fresh || ! cache_has_items; then
+    refresh || true
+  fi
+  emit_list
+}
+
+widget() {
+  local state n overdue error mark color
+  local bg="#f2f0e5" fg="#100f0f" red="#d14d41"
+  local reset="#[fg=$fg,bg=$bg,nobold,noitalics,nounderscore,nodim]"
+  local slack
+
+  slack=$(printf '\uF198')
+  if ! find "$CACHE" -mmin -15 2>/dev/null | grep -q .; then
+    tmux-slack-later-refresh >/dev/null 2>&1 &
+  fi
+  [[ -f "$CACHE" ]] || return 0
+
+  state=$(jq -r '
+    def count: type == "number" and . >= 0 and floor == .;
+    if (.counts | type == "object")
+      and (.counts.uncompleted_count | count)
+      and (.counts.uncompleted_overdue_count | count)
+    then [
+      (.counts.uncompleted_count | tostring),
+      (.counts.uncompleted_overdue_count | tostring),
+      (if .error == null or .error == "" then "" elif (.error | type) == "string" then .error else "malformed" end)
+    ]
+    else ["0", "0", "malformed"]
+    end | @tsv
+  ' "$CACHE" 2>/dev/null) || state=$'0\t0\tmalformed'
+  IFS=$'\t' read -r n overdue error <<<"$state"
+  case "$n" in "" | *[!0-9]*) n=0; error=${error:-malformed} ;; esac
+  case "$overdue" in "" | *[!0-9]*) overdue=0; error=${error:-malformed} ;; esac
+
+  mark=""
+  [[ -z "$error" ]] || mark=" #[fg=$red]!"
+  [[ $n -gt 0 || -n "$mark" ]] || return 0
+  [[ $overdue -gt 0 ]] && color=$red || color=$fg
+  printf '#[fg=%s,bg=%s,bold] %s %s%s%s \n' "$color" "$bg" "$slack" "$n" "$mark" "$reset"
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  case ${1:-} in
+    refresh | widget)
+      configure || exit 64
+      "$1"
+      ;;
+    list)
+      if configure; then
+        list
+      else
+        empty_list "${CONFIG_ERROR:-configuration}"
+      fi
+      ;;
+    *) exit 64 ;;
+  esac
+fi

--- a/modules/chat/slack/later.sh
+++ b/modules/chat/slack/later.sh
@@ -137,8 +137,11 @@ cache_has_items() {
   valid_list <"$CACHE" >/dev/null 2>&1
 }
 
+# 2>/dev/null before the input redirect, not after: an absent cache is a normal
+# --cached state, and bash reports a failed redirect against whatever stderr is
+# at that point in the line.
 emit_list() {
-  valid_list <"$CACHE" 2>/dev/null || empty_list "cache"
+  valid_list 2>/dev/null <"$CACHE" || empty_list "${1:-cache}"
 }
 
 cookie_database() {
@@ -553,7 +556,14 @@ refresh() {
   publish_error "credentials"
 }
 
+# --cached never fetches. A stale or absent cache is something a caller can put
+# on screen now and correct later, so the wait for a real refresh — minutes, in
+# the worst case — belongs to a caller that asked for one, not to a first paint.
 list() {
+  if [[ ${1:-} == --cached ]]; then
+    emit_list loading
+    return
+  fi
   if ! cache_fresh || ! cache_has_items; then
     refresh || true
   fi
@@ -603,8 +613,9 @@ if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
       "$1"
       ;;
     list)
+      case ${2:-} in "" | --cached) ;; *) exit 64 ;; esac
       if configure; then
-        list
+        list "${2:-}"
       else
         empty_list "${CONFIG_ERROR:-configuration}"
       fi

--- a/modules/chat/slack/later.test.sh
+++ b/modules/chat/slack/later.test.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# Run by hand: bash later.test.sh
+set -euo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)/later.sh"
+TMP=$(mktemp -d)
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+export TMUX_SLACK_LATER_CACHE_ROOT="$TMP/cache"
+export TMPDIR="$TMP/tmp"
+export TMUX_SLACK_LATER_CHROME_VERSION=123.0.0.0
+mkdir -p "$TMPDIR" "$TMP/bin"
+
+OPENSSL=${TMUX_SLACK_LATER_OPENSSL:-openssl}
+if ! "$OPENSSL" enc -help 2>&1 | grep -q -- '-saltlen'; then
+  OPENSSL="$(nix path-info --offline nixpkgs#openssl 2>/dev/null | head -n 1)/bin/openssl"
+fi
+[[ -x "$OPENSSL" ]] || {
+  echo 'FAIL OpenSSL with -saltlen support is required' >&2
+  exit 1
+}
+export PATH="$TMP/bin:${OPENSSL%/*}:$PATH"
+
+namespace() {
+  printf '%s\0%s' "$TMUX_SLACK_LATER_PROFILE" "$TMUX_SLACK_LATER_WORKSPACE" \
+    | sha256sum | awk '{ print $1 }'
+}
+
+cache() {
+  printf '%s/%s.json' "$TMUX_SLACK_LATER_CACHE_ROOT" "$(namespace)"
+}
+
+check() {
+  local label=$1 expected=$2 actual=$3
+  if [[ "$actual" == "$expected" ]]; then
+    printf 'ok   %s\n' "$label"
+  else
+    printf 'FAIL %s: expected %s, got %s\n' "$label" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+contains() {
+  local label=$1 needle=$2 haystack=$3
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf 'ok   %s\n' "$label"
+  else
+    printf 'FAIL %s: expected %s in %s\n' "$label" "$needle" "$haystack" >&2
+    exit 1
+  fi
+}
+
+not_contains() {
+  local label=$1 needle=$2 haystack=$3
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf 'ok   %s\n' "$label"
+  else
+    printf 'FAIL %s: did not expect %s in %s\n' "$label" "$needle" "$haystack" >&2
+    exit 1
+  fi
+}
+
+chrome_key() {
+  local result
+  export CHROME_SAFE_STORAGE_PASSWORD=test
+  result=$("$OPENSSL" enc -aes-128-cbc -P -md sha1 -iter 1003 -saltlen 9 \
+    -pass env:CHROME_SAFE_STORAGE_PASSWORD \
+    -S 73616c747973616c74 2>/dev/null | awk -F= '/^key=/{ print $2 }')
+  unset CHROME_SAFE_STORAGE_PASSWORD
+  printf '%s' "$result"
+}
+
+key=$(chrome_key)
+check "Chromium PBKDF2 vector" "63009C1422826BB1E156C7A1A4F5B5A8" "$key"
+
+encrypted_hex() {
+  local domain=$1 value=$2 blob="$TMP/cookie.blob"
+  {
+    printf 'v10'
+    {
+      printf '%s' "$domain" | "$OPENSSL" dgst -sha256 -binary
+      printf '%s' "$value"
+    } | "$OPENSSL" enc -aes-128-cbc -K "$key" \
+      -iv 20202020202020202020202020202020
+  } >"$blob"
+  od -An -tx1 -v "$blob" | tr -d ' \n'
+}
+
+add_plain_cookie() {
+  local db=$1 created=$2 domain=$3 name=$4 value=$5 path=$6 expires=$7 secure=$8
+  sqlite3 "$db" "
+    insert into cookies
+      (creation_utc, host_key, name, value, encrypted_value, path, expires_utc, is_secure)
+    values ($created, '$domain', '$name', '$value', X'', '$path', $expires, $secure);
+  "
+}
+
+add_encrypted_cookie() {
+  local db=$1 created=$2 domain=$3 name=$4 value=$5 path=$6 expires=$7 secure=$8 encrypted
+  encrypted=$(encrypted_hex "$domain" "$value")
+  sqlite3 "$db" "
+    insert into cookies
+      (creation_utc, host_key, name, value, encrypted_value, path, expires_utc, is_secure)
+    values ($created, '$domain', '$name', '', X'$encrypted', '$path', $expires, $secure);
+  "
+}
+
+create_profile() {
+  local profile=$1
+  local db="$profile/Cookies"
+  mkdir -p "$profile/Local Storage/leveldb"
+  sqlite3 "$db" <<'SQL'
+create table meta (key longvarchar not null unique primary key, value longvarchar);
+insert into meta values ('version', '24');
+create table cookies (
+  creation_utc integer primary key,
+  host_key text not null,
+  name text not null,
+  value text not null,
+  encrypted_value blob not null,
+  path text not null,
+  expires_utc integer not null,
+  is_secure integer not null
+);
+SQL
+  add_encrypted_cookie "$db" 1 '.slack.com' d 'xoxd-encrypted%2Fvalue' / 0 1
+  add_plain_cookie "$db" 2 '.slack.com' d-s 'plain-d-s%2Fvalue' / 0 1
+  add_plain_cookie "$db" 3 'telepatiaworkspace.slack.com' workspace 'workspace%2Fvalue' /api 0 1
+  add_plain_cookie "$db" 4 '.slack.com' insecure 'insecure%2Fvalue' /api 0 0
+  add_plain_cookie "$db" 5 'slack.com' parent-host-only 'must-not-send' / 0 1
+  add_plain_cookie "$db" 6 '.other.slack.com' other-domain 'must-not-send' / 0 1
+  add_plain_cookie "$db" 7 '.slack.com' expired 'must-not-send' / 1 1
+  add_plain_cookie "$db" 8 '.slack.com' wrong-path 'must-not-send' /other 0 1
+  printf '%s\n' "$FIRST_TOKEN" "$SECOND_TOKEN" >"$profile/Local Storage/leveldb/000001.ldb"
+}
+
+export FIRST_TOKEN="xoxc-first-12345678901234567890"
+export SECOND_TOKEN="xoxc-second-12345678901234567890"
+export SECURITY_LOG="$TMP/security.log"
+export CURL_LOG="$TMP/curl.log"
+export CURL_ARGV_LOG="$TMP/curl.argv"
+export JAR_CAPTURE="$TMP/cookies.txt"
+export BATCH_LOG="$TMP/batches.log"
+
+export SAVED_RESPONSE
+SAVED_RESPONSE=$(cat <<'JSON'
+{"ok":true,"counts":{"uncompleted_count":52,"uncompleted_overdue_count":0},"saved_items":[
+{"item_id":"C01","item_type":"message","ts":"1700000001.000001","state":"saved","todo_state":"not_started","date_created":1700000001,"date_due":null},
+{"item_id":"C02","item_type":"message","ts":"1700000002.000002","state":"saved","todo_state":"not_started","date_created":1700000002,"date_due":1700100002},
+{"item_id":"C03","item_type":"message","ts":"1700000003.000003","state":"saved","todo_state":"not_started","date_created":1700000003,"date_due":null},
+{"item_id":"C04","item_type":"message","ts":"1700000004.000004","state":"saved","todo_state":"not_started","date_created":1700000004,"date_due":null},
+{"item_id":"C05","item_type":"message","ts":"1700000005.000005","state":"saved","todo_state":"not_started","date_created":1700000005,"date_due":null},
+{"item_id":"C06","item_type":"message","ts":"1700000006.000006","state":"saved","todo_state":"not_started","date_created":1700000006,"date_due":null},
+{"item_id":"C07","item_type":"message","ts":"1700000007.000007","state":"saved","todo_state":"not_started","date_created":1700000007,"date_due":null},
+{"item_id":"C08","item_type":"message","ts":"1700000008.000008","state":"saved","todo_state":"not_started","date_created":1700000008,"date_due":null},
+{"item_id":"C09","item_type":"message","ts":"1700000009.000009","state":"saved","todo_state":"not_started","date_created":1700000009,"date_due":null},
+{"item_id":"C10","item_type":"message","ts":"1700000010.000010","state":"saved","todo_state":"not_started","date_created":1700000010,"date_due":null},
+{"item_id":"C11","item_type":"message","ts":"1700000011.000011","state":"saved","todo_state":"not_started","date_created":1700000011,"date_due":null},
+{"item_id":"F01","item_type":"file","ts":"1700000012.000012","state":"saved","todo_state":"not_started","date_created":1700000012,"date_due":null}
+],"response_metadata":{"next_cursor":"next-page"}}
+JSON
+)
+
+export MESSAGE_RESPONSE
+MESSAGE_RESPONSE=$(cat <<'JSON'
+{"ok":true,"messages":{"C01":[{"ts":"1700000001.000001","text":"One <https://example.invalid|summary>\n"}],"C02":[{"ts":"1700000002.000002","text":"Two"}],"C03":[{"ts":"1700000003.000003","text":"Three"}],"C04":[{"ts":"1700000004.000004","text":"Four"}],"C05":[{"ts":"1700000005.000005","text":"Five"}],"C06":[{"ts":"1700000006.000006","text":"Six"}],"C07":[{"ts":"1700000007.000007","text":"Seven"}],"C08":[{"ts":"1700000008.000008","text":"Eight"}],"C09":[{"ts":"1700000009.000009","text":"Nine"}],"C10":[{"ts":"1700000010.000010","text":"Ten"}],"C11":[{"ts":"1700000011.000011","text":"Eleven"}]}}
+JSON
+)
+
+cat >"$TMP/bin/security" <<'EOF'
+#!/usr/bin/env bash
+printf 'security\n' >>"$SECURITY_LOG"
+printf 'test\n'
+EOF
+cat >"$TMP/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CURL_ARGV_LOG"
+config=$(cat)
+printf '%s\n---\n' "$config" >>"$CURL_LOG"
+jar=$(printf '%s\n' "$config" | sed -n 's/^cookie = "\(.*\)"$/\1/p')
+[[ -r "$jar" ]] || exit 1
+cp "$jar" "$JAR_CAPTURE"
+grep -Fq $'\td\txoxd-encrypted%2Fvalue' "$jar" || exit 1
+grep -Fq $'\td-s\tplain-d-s%2Fvalue' "$jar" || exit 1
+grep -Fq $'\tworkspace\tworkspace%2Fvalue' "$jar" || exit 1
+case "$MOCK_MODE" in
+  success)
+    case "$config" in
+      *auth.test*) printf '%s\n' '{"ok":true,"url":"https://telepatiaworkspace.slack.com/"}' ;;
+      *saved.list*) printf '%s\n' "$SAVED_RESPONSE" ;;
+      *messages.list*)
+        message_ids=$(sed -n 's/^data-urlencode = "message_ids=\(.*\)"$/\1/p' <<<"$config")
+        channel_count=$(grep -o 'channel' <<<"$message_ids" | wc -l | tr -d ' ')
+        (( channel_count > 0 && channel_count <= 10 )) || exit 1
+        printf '%s\n' "$channel_count" >>"$BATCH_LOG"
+        printf '%s\n' "$MESSAGE_RESPONSE"
+        ;;
+    esac
+    ;;
+  wrong)
+    case "$config" in
+      *auth.test*) printf '%s\n' '{"ok":true,"url":"https://wrong.slack.com/"}' ;;
+      *saved.list*) exit 1 ;;
+    esac
+    ;;
+  server-error)
+    case "$config" in
+      *auth.test*) printf '%s\n' '{"ok":true,"url":"https://telepatiaworkspace.slack.com/"}' ;;
+      *saved.list*) printf '%s\n' '{"ok":false,"error":"ratelimited"}' ;;
+    esac
+    ;;
+  messages-error)
+    case "$config" in
+      *auth.test*) printf '%s\n' '{"ok":true,"url":"https://telepatiaworkspace.slack.com/"}' ;;
+      *saved.list*) printf '%s\n' "$SAVED_RESPONSE" ;;
+      *messages.list*) printf '%s\n' '{"ok":false,"error":"ratelimited"}' ;;
+    esac
+    ;;
+esac
+EOF
+chmod +x "$TMP/bin/security" "$TMP/bin/curl"
+export TMUX_SLACK_LATER_SECURITY="$TMP/bin/security"
+
+export TMUX_SLACK_LATER_PROFILE="$TMP/missing/Default"
+export TMUX_SLACK_LATER_WORKSPACE="telepatiaworkspace.slack.com"
+missing_list=$(bash "$SRC" list)
+first_cache=$(cache)
+check "absent profile records profile error" "profile" "$(jq -r '.error' "$first_cache")"
+check "absent profile list count is zero" "0" "$(jq -r '.counts.uncompleted_count' <<<"$missing_list")"
+check "absent profile list has no items" "0" "$(jq '.items | length' <<<"$missing_list")"
+contains "absent profile error is visible" "!" "$(bash "$SRC" widget)"
+
+# 2. The workspace is part of the cache key, not just the source profile.
+export TMUX_SLACK_LATER_WORKSPACE="other.slack.com"
+bash "$SRC" refresh
+second_cache=$(cache)
+[[ "$first_cache" != "$second_cache" ]] || {
+  echo "FAIL workspace did not change cache namespace" >&2
+  exit 1
+}
+check "workspace cache is independently initialized" "profile" "$(jq -r '.error' "$second_cache")"
+check "first workspace cache remains intact" "profile" "$(jq -r '.error' "$first_cache")"
+printf 'ok   source and workspace cache isolation\n'
+
+# 3. A corrupt count is a red error, never a silent zero.
+export TMUX_SLACK_LATER_WORKSPACE="telepatiaworkspace.slack.com"
+malformed_cache=$(cache)
+cat >"$malformed_cache" <<'EOF'
+{"counts":{"uncompleted_count":"many","uncompleted_overdue_count":0},"error":""}
+EOF
+contains "malformed counts are visible" "!" "$(bash "$SRC" widget)"
+
+# 4. Full applicable cookies (encrypted and plaintext) authenticate an exact
+# workspace auth.test before saved.list. This fixture fails the former d-only
+# request shape without reading Chrome, the keychain, or Slack.
+export TMUX_SLACK_LATER_PROFILE="$TMP/chrome-success/Default"
+create_profile "$TMUX_SLACK_LATER_PROFILE"
+success_cache=$(cache)
+: >"$SECURITY_LOG"
+: >"$CURL_LOG"
+: >"$CURL_ARGV_LOG"
+: >"$BATCH_LOG"
+MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" refresh
+check "full cookie request publishes 52" "52" "$(jq -r '.counts.uncompleted_count' "$success_cache")"
+check "full cookie request clears error" "" "$(jq -r '.error' "$success_cache")"
+check "full cookie request stores every saved item" "12" "$(jq '.items | length' "$success_cache")"
+check "message id combines channel and timestamp" "C01:1700000001.000001" "$(jq -r '.items[0].id' "$success_cache")"
+check "message title is compact and sanitized" "One summary" "$(jq -r '.items[0].title' "$success_cache")"
+check "message url is stable" "https://telepatiaworkspace.slack.com/archives/C01/p1700000001000001" "$(jq -r '.items[0].url' "$success_cache")"
+check "unresolved non-message uses fallback title" "Message unavailable" "$(jq -r '.items[11].title' "$success_cache")"
+check "unresolved non-message uses workspace url" "https://telepatiaworkspace.slack.com" "$(jq -r '.items[11].url' "$success_cache")"
+check "cursor marks bounded result truncated" "true" "$(jq -r '.truncated' "$success_cache")"
+check "cache is private" "600" "$(/usr/bin/stat -f '%Lp' "$success_cache")"
+check "derives Chrome key once" "1" "$(wc -l <"$SECURITY_LOG" | tr -d ' ')"
+contains "request uses workspace host" 'url = "https://telepatiaworkspace.slack.com/api/auth.test"' "$(cat "$CURL_LOG")"
+contains "request posts supported saved limit 49" 'data-urlencode = "limit=49"' "$(cat "$CURL_LOG")"
+contains "request URLencodes message ids" 'data-urlencode = "message_ids=[{\"channel\":\"C01\"' "$(cat "$CURL_LOG")"
+check "message hydration has two channel batches" $'10\n1' "$(cat "$BATCH_LOG")"
+contains "request uses Chrome user agent" 'Chrome/123.0.0.0 Safari' "$(cat "$CURL_LOG")"
+not_contains "request does not use bearer auth" "Authorization:" "$(cat "$CURL_LOG")"
+contains "jar preserves encrypted d" $'\td\txoxd-encrypted%2Fvalue' "$(cat "$JAR_CAPTURE")"
+contains "jar preserves plaintext d-s" $'\td-s\tplain-d-s%2Fvalue' "$(cat "$JAR_CAPTURE")"
+contains "jar keeps workspace cookie" $'\tworkspace\tworkspace%2Fvalue' "$(cat "$JAR_CAPTURE")"
+contains "jar preserves insecure metadata" $'\tFALSE\t0\tinsecure\tinsecure%2Fvalue' "$(cat "$JAR_CAPTURE")"
+not_contains "jar excludes parent host-only cookie" "parent-host-only" "$(cat "$JAR_CAPTURE")"
+not_contains "jar excludes other domain" "other-domain" "$(cat "$JAR_CAPTURE")"
+not_contains "jar excludes expired cookie" "expired" "$(cat "$JAR_CAPTURE")"
+not_contains "jar excludes non-api path" "wrong-path" "$(cat "$JAR_CAPTURE")"
+if grep -Eq 'xox[c,d]-|plain-d-s|workspace%2Fvalue' "$CURL_ARGV_LOG"; then
+  echo "FAIL credentials appeared in curl argv" >&2
+  exit 1
+fi
+printf 'ok   curl argv excludes credentials\n'
+
+: >"$CURL_LOG"
+fresh_list=$(MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" list)
+check "fresh list returns cached title" "One summary" "$(jq -r '.items[0].title' <<<"$fresh_list")"
+[[ ! -s "$CURL_LOG" ]] || {
+  echo "FAIL fresh list made an HTTP request" >&2
+  exit 1
+}
+printf 'ok   fresh list makes no HTTP request\n'
+
+cat >"$success_cache" <<'EOF'
+{"counts":{"uncompleted_count":52,"uncompleted_overdue_count":0},"error":""}
+EOF
+: >"$CURL_LOG"
+: >"$BATCH_LOG"
+count_only_list=$(MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" list)
+check "count-only cache hydrates rows" "12" "$(jq '.items | length' <<<"$count_only_list")"
+check "count-only cache refreshes saved list" "1" "$(grep -c saved.list "$CURL_LOG" | tr -d ' ')"
+check "count-only cache hydrates in batches" $'10\n1' "$(cat "$BATCH_LOG")"
+
+export TMUX_SLACK_LATER_PROFILE="$TMP/chrome-wrong/Default"
+create_profile "$TMUX_SLACK_LATER_PROFILE"
+wrong_cache=$(cache)
+: >"$CURL_LOG"
+MOCK_MODE=wrong PATH="$TMP/bin:$PATH" bash "$SRC" refresh
+check "wrong workspace publishes credentials error" "credentials" "$(jq -r '.error' "$wrong_cache")"
+contains "wrong workspace calls auth.test" "auth.test" "$(cat "$CURL_LOG")"
+not_contains "wrong workspace skips saved.list" "saved.list" "$(cat "$CURL_LOG")"
+
+export TMUX_SLACK_LATER_PROFILE="$TMP/chrome-server-error/Default"
+create_profile "$TMUX_SLACK_LATER_PROFILE"
+server_error_cache=$(cache)
+: >"$CURL_LOG"
+MOCK_MODE=server-error PATH="$TMP/bin:$PATH" bash "$SRC" refresh
+check "server error is visible" "network" "$(jq -r '.error' "$server_error_cache")"
+contains "first candidate was attempted" "$FIRST_TOKEN" "$(cat "$CURL_LOG")"
+not_contains "server error stops second candidate" "$SECOND_TOKEN" "$(cat "$CURL_LOG")"
+
+export TMUX_SLACK_LATER_PROFILE="$TMP/chrome-success/Default"
+preserved_items=$(jq -c '.items' "$success_cache")
+: >"$CURL_LOG"
+MOCK_MODE=messages-error PATH="$TMP/bin:$PATH" bash "$SRC" refresh
+check "hydration failure is visible" "network" "$(jq -r '.error' "$success_cache")"
+check "hydration failure preserves rows" "$preserved_items" "$(jq -c '.items' "$success_cache")"
+contains "hydration attempts first candidate" "$FIRST_TOKEN" "$(cat "$CURL_LOG")"
+not_contains "hydration does not probe second candidate" "$SECOND_TOKEN" "$(cat "$CURL_LOG")"

--- a/modules/chat/slack/later.test.sh
+++ b/modules/chat/slack/later.test.sh
@@ -227,6 +227,24 @@ export TMUX_SLACK_LATER_SECURITY="$TMP/bin/security"
 
 export TMUX_SLACK_LATER_PROFILE="$TMP/missing/Default"
 export TMUX_SLACK_LATER_WORKSPACE="telepatiaworkspace.slack.com"
+
+# 0. --cached answers from disk and never fetches — this is what lets a caller
+# paint before the network. Nothing has run yet, so the cache root is absent: a
+# refresh that slipped in would have had to mkdir it, and would have hit curl.
+: >"$CURL_LOG"
+cached_cold=$(bash "$SRC" list --cached)
+check "cold --cached reports loading" "loading" "$(jq -r '.error' <<<"$cached_cold")"
+check "cold --cached still returns a list" "0" "$(jq '.items | length' <<<"$cached_cold")"
+check "cold --cached writes no cache" "absent" \
+  "$([[ -e "$TMUX_SLACK_LATER_CACHE_ROOT" ]] && echo present || echo absent)"
+[[ ! -s "$CURL_LOG" ]] || {
+  echo "FAIL --cached made an HTTP request" >&2
+  exit 1
+}
+printf 'ok   cold --cached makes no HTTP request\n'
+check "list rejects an unknown flag" "64" \
+  "$(bash "$SRC" list --nope >/dev/null 2>&1 || echo $?)"
+
 missing_list=$(bash "$SRC" list)
 first_cache=$(cache)
 check "absent profile records profile error" "profile" "$(jq -r '.error' "$first_cache")"
@@ -304,6 +322,19 @@ check "fresh list returns cached title" "One summary" "$(jq -r '.items[0].title'
   exit 1
 }
 printf 'ok   fresh list makes no HTTP request\n'
+
+# A stale cache is precisely the case plain `list` spends a refresh on. --cached
+# hands the stale rows over untouched instead, which is a caller's first frame.
+touch -t 200001010000 "$success_cache"
+: >"$CURL_LOG"
+stale_cached=$(MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" list --cached)
+check "stale --cached serves the stale rows" "12" "$(jq '.items | length' <<<"$stale_cached")"
+check "stale --cached does not mark them loading" "" "$(jq -r '.error' <<<"$stale_cached")"
+[[ ! -s "$CURL_LOG" ]] || {
+  echo "FAIL stale --cached made an HTTP request" >&2
+  exit 1
+}
+printf 'ok   stale --cached makes no HTTP request\n'
 
 cat >"$success_cache" <<'EOF'
 {"counts":{"uncompleted_count":52,"uncompleted_overdue_count":0},"error":""}

--- a/modules/chat/slack/slack.nix
+++ b/modules/chat/slack/slack.nix
@@ -1,0 +1,16 @@
+{
+  mkUserModule,
+  pkgs,
+  lib,
+  ...
+}:
+mkUserModule {
+  name = "slack";
+  casks = [ "slack" ];
+
+  parts = {
+    # Explicit opt-in: reads only the dedicated Chrome profile, using Chrome
+    # Safe Storage from the login keychain to decrypt its cookies.
+    later = import ./later.nix { inherit pkgs lib; };
+  };
+}

--- a/modules/users/vega-fernando.nix
+++ b/modules/users/vega-fernando.nix
@@ -119,7 +119,11 @@ mkUser {
   ghostty.enable = true;
 
   # Chat & communication
-  slack.enable = true;
+  slack = {
+    enable = true;
+    later.workspace = "telepatiaworkspace.slack.com";
+    later.enable = true;
+  };
   teams.enable = true;
   telegram.enable = true;
   whatsapp.enable = true;


### PR DESCRIPTION
## Summary

- Add an opt-in Slack Later count to the tmux statusbar and a read-only `prefix + L` right-hand pane.
- Use only a dedicated Chrome profile, verify the exact workspace, and preserve the complete applicable cookie set when making workspace-scoped form requests.
- Cache counts and message snippets privately for 15 minutes. Hydrate messages in batches; display stale/error and truncation states explicitly.
- Support Enter to open a message, `/` to search, `r` to refresh, and `q`/Esc to close the pane.

## Verification

- Both offline shell regression suites pass: 58 backend checks and 36 pane checks.
- Cold and stale-cache panes render immediately; background loading preserves keyboard interaction and updates rows/header when complete.
- ShellCheck, nixfmt, Statix, and `git diff --check` pass.
- `nix flake check` and the vega system build pass from a clean worktree based on current main.
- Live verification before PR preparation matched the Telepatia count and loaded every current item with message text. Tested search and pane closure in an isolated tmux session.
- Five review areas passed: goal, hands-on QA, code, security, and repository context.

## Boundaries

- Slack's Later endpoints are undocumented. This is explicitly opt-in and does not guarantee immunity from Slack session expiry or revocation.
- The dedicated Chrome profile must already be signed in; Chrome Safe Storage from the macOS Keychain decrypts only that profile's applicable cookies.
- The pane is read-only. No message sends, task completions, or other Slack mutations.
- Slack limits a page to fewer than 50 items. The pane shows up to 49 and labels additional results as truncated.
- Experiment logs, credentials, real message content, and unrelated local changes are excluded from this PR.
