### PR TITLE
fix(slack): stop standalone reminders inflating the Later count

### DIFF
--- a/modules/chat/slack/later.sh
+++ b/modules/chat/slack/later.sh
@@ -397,6 +397,13 @@ hydration_batches() {
   '
 }
 
+# Saved messages only, by the same predicate hydration_batches fetches by. A
+# standalone reminder has no message behind it — no channel, no timestamp — so
+# it can only be an unopenable row and a +1 nobody can act on. Both counts are
+# derived here rather than taken from the response: Slack's own counts include
+# those reminders.
+# ponytail: the count is what one 49-item page holds, so a truncated list
+# undercounts — page through saved.list if that ever bites.
 materialize_saved() {
   local saved=$1 messages=$2
   jq -ce --arg workspace "$WORKSPACE" --slurpfile messages "$messages" '
@@ -414,34 +421,24 @@ materialize_saved() {
       [$messages[0][$channel][]?
         | select((.ts? | type) == "string" and .ts == $timestamp)
         | .text? | select(type == "string")][0] // "";
-    {
+    [.saved_items[]?
+      | select(.item_type == "message" and (.item_id | channel) and (.ts | timestamp))
+    ] as $messages_saved
+    | {
       counts: {
-        uncompleted_count: .counts.uncompleted_count,
-        uncompleted_overdue_count: .counts.uncompleted_overdue_count
+        uncompleted_count: ($messages_saved | length),
+        uncompleted_overdue_count: ([$messages_saved[]
+          | select((.date_due | type) == "number" and .date_due < now)] | length)
       },
-      items: [
-        .saved_items | to_entries[]
-        | .key as $index | .value
-        | . as $item
-        | ($item.item_id? // null) as $channel
-        | ($item.ts? // null) as $timestamp
+      items: [$messages_saved[]
+        | .item_id as $channel
+        | .ts as $timestamp
         | {
-          id: (if ($channel | channel) and ($timestamp | timestamp)
-            then "\($channel):\($timestamp)"
-            else "item:\($index)"
-            end),
-          title: (if $item.item_type == "message"
-              and ($channel | channel) and ($timestamp | timestamp)
-            then message_text($channel; $timestamp) | clean_title
-            else "Message unavailable"
-            end),
-          url: (if $item.item_type == "message"
-              and ($channel | channel) and ($timestamp | timestamp)
-            then "https://\($workspace)/archives/\($channel)/p\($timestamp | gsub("\\."; ""))"
-            else "https://\($workspace)"
-            end),
-          date_created: (if ($item.date_created? | date) then $item.date_created else null end),
-          date_due: (if ($item.date_due? | date) then $item.date_due else null end)
+          id: "\($channel):\($timestamp)",
+          title: (message_text($channel; $timestamp) | clean_title),
+          url: "https://\($workspace)/archives/\($channel)/p\($timestamp | gsub("\\."; ""))",
+          date_created: (if (.date_created? | date) then .date_created else null end),
+          date_due: (if (.date_due? | date) then .date_due else null end)
         }
       ],
       error: "",

--- a/modules/chat/slack/later.test.sh
+++ b/modules/chat/slack/later.test.sh
@@ -283,14 +283,14 @@ success_cache=$(cache)
 : >"$CURL_ARGV_LOG"
 : >"$BATCH_LOG"
 MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" refresh
-check "full cookie request publishes 52" "52" "$(jq -r '.counts.uncompleted_count' "$success_cache")"
+check "count excludes the non-message item" "11" "$(jq -r '.counts.uncompleted_count' "$success_cache")"
 check "full cookie request clears error" "" "$(jq -r '.error' "$success_cache")"
-check "full cookie request stores every saved item" "12" "$(jq '.items | length' "$success_cache")"
+check "full cookie request stores every saved message" "11" "$(jq '.items | length' "$success_cache")"
+check "non-message items are dropped" "" "$(jq -r '.items[] | select(.url == "https://telepatiaworkspace.slack.com") | .id' "$success_cache")"
+check "overdue is derived from message due dates" "1" "$(jq -r '.counts.uncompleted_overdue_count' "$success_cache")"
 check "message id combines channel and timestamp" "C01:1700000001.000001" "$(jq -r '.items[0].id' "$success_cache")"
 check "message title is compact and sanitized" "One summary" "$(jq -r '.items[0].title' "$success_cache")"
 check "message url is stable" "https://telepatiaworkspace.slack.com/archives/C01/p1700000001000001" "$(jq -r '.items[0].url' "$success_cache")"
-check "unresolved non-message uses fallback title" "Message unavailable" "$(jq -r '.items[11].title' "$success_cache")"
-check "unresolved non-message uses workspace url" "https://telepatiaworkspace.slack.com" "$(jq -r '.items[11].url' "$success_cache")"
 check "cursor marks bounded result truncated" "true" "$(jq -r '.truncated' "$success_cache")"
 check "cache is private" "600" "$(/usr/bin/stat -f '%Lp' "$success_cache")"
 check "derives Chrome key once" "1" "$(wc -l <"$SECURITY_LOG" | tr -d ' ')"
@@ -328,7 +328,7 @@ printf 'ok   fresh list makes no HTTP request\n'
 touch -t 200001010000 "$success_cache"
 : >"$CURL_LOG"
 stale_cached=$(MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" list --cached)
-check "stale --cached serves the stale rows" "12" "$(jq '.items | length' <<<"$stale_cached")"
+check "stale --cached serves the stale rows" "11" "$(jq '.items | length' <<<"$stale_cached")"
 check "stale --cached does not mark them loading" "" "$(jq -r '.error' <<<"$stale_cached")"
 [[ ! -s "$CURL_LOG" ]] || {
   echo "FAIL stale --cached made an HTTP request" >&2
@@ -342,7 +342,7 @@ EOF
 : >"$CURL_LOG"
 : >"$BATCH_LOG"
 count_only_list=$(MOCK_MODE=success PATH="$TMP/bin:$PATH" bash "$SRC" list)
-check "count-only cache hydrates rows" "12" "$(jq '.items | length' <<<"$count_only_list")"
+check "count-only cache hydrates rows" "11" "$(jq '.items | length' <<<"$count_only_list")"
 check "count-only cache refreshes saved list" "1" "$(grep -c saved.list "$CURL_LOG" | tr -d ' ')"
 check "count-only cache hydrates in batches" $'10\n1' "$(cat "$BATCH_LOG")"
 


### PR DESCRIPTION
Slack's Later list holds two different things: messages you saved, and
reminders with no message behind them. saved.list returns both, and its
counts cover both, so a bare reminder arrived as a +1 in the bar and an
unopenable "Message unavailable" row in the pane — which was the entire
contents of my Later list: a count of one that nothing could act on.

materialize_saved now keeps only the items that resolve to a real
message, by the same (item_type, channel, timestamp) predicate
hydration_batches already fetches by, and derives both counts from those
rather than reading them off the response. Deriving is the part that
makes the number actually drop: uncompleted_count includes the reminders
however we render them. uncompleted_overdue_count is derived the same
way from date_due, so an overdue reminder can no longer paint the bar red
on its own, and a saved message with a due date still can.

That leaves the fallback branch — "Message unavailable" and the bare
workspace url — with nothing to catch, so it goes too, and the change is
three lines shorter than what it replaces.

The count is now what one 49-item page holds, so a Later list longer than
that undercounts where it previously showed Slack's own total. Marked in
place; paging saved.list is the fix if that ever bites.

Verified against the real workspace: the refresh that published one
unopenable row now publishes none, and the widget prints nothing, so the
segment leaves the bar entirely rather than showing a zero. 50 backend
checks and 20 pane checks pass, two of them new.